### PR TITLE
Feature/#13-textarea

### DIFF
--- a/components/common/textarea.tsx
+++ b/components/common/textarea.tsx
@@ -25,6 +25,7 @@ const StyledTextarea = styled.textarea`
   background-color: #fff;
   outline: 0;
   box-sizing: border-box;
+  resize: none;
 
   &:focus {
     box-shadow: 0px 0px 1px 2px ${theme.color.$skyBlue};

--- a/components/common/textarea.tsx
+++ b/components/common/textarea.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+import * as theme from "@/styles/theme";
+import { forwardRef } from "react";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  width?: string;
+  height?: string;
+}
+
+const Textarea = forwardRef(
+  (
+    { width = "470px", height = "155px", ...props }: TextareaProps,
+    ref?: React.Ref<HTMLTextAreaElement>
+  ) => {
+    return <StyledTextarea style={{ width, height }} {...props} ref={ref} />;
+  }
+);
+
+const StyledTextarea = styled.textarea`
+  border: 1px solid ${theme.color.$gray600};
+  border-radius: 8px;
+  padding: 10px 15px;
+  ${theme.text.$body1}
+  background-color: #fff;
+  outline: 0;
+  box-sizing: border-box;
+
+  &:focus {
+    box-shadow: 0px 0px 1px 2px ${theme.color.$skyBlue};
+  }
+`;
+
+export default Textarea;

--- a/stories/components/textarea.stories.tsx
+++ b/stories/components/textarea.stories.tsx
@@ -1,0 +1,52 @@
+import Textarea, { TextareaProps } from "@/components/common/textarea";
+import { useRef, useState } from "react";
+
+export default {
+  title: "Components/Textarea",
+  component: Textarea,
+  argTypes: {
+    width: { control: "text", defaultValue: "470px" },
+    height: { control: "text", defaultValue: "155px" },
+  },
+};
+
+export const Default = (args: TextareaProps) => <Textarea {...args} />;
+
+export const StyleCustom = (args: TextareaProps) => (
+  <Textarea
+    placeholder="placeholder"
+    style={{ width: "300px", padding: "20px", fontSize: "30px" }}
+    {...args}
+  />
+);
+StyleCustom.parameters = {
+  controls: { exclude: ["width", "height"] },
+};
+
+export const WithState = (args: TextareaProps) => {
+  const [bio, setBio] = useState("I'm groot");
+
+  return (
+    <>
+      <div>bio: {bio}</div>
+      <Textarea
+        value={bio}
+        onChange={(e) => setBio(e.target.value)}
+        {...args}
+      />
+    </>
+  );
+};
+
+export const WithRef = (args: TextareaProps) => {
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  return (
+    <>
+      <button type="button" onClick={() => inputRef.current?.focus()}>
+        textarea focus!
+      </button>
+      <Textarea ref={inputRef} {...args} />
+    </>
+  );
+};


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [x] textarea 컴포넌트 구현
- 피그마 디자인
  ![textarea bio](https://user-images.githubusercontent.com/96400112/181698028-e672bb80-ce14-4403-8835-ed9a06f7bf29.PNG)
  ![textarea 설명](https://user-images.githubusercontent.com/96400112/181698036-4348cf70-841e-4203-8992-91ea195da242.PNG)

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
## props
- `width`: string, optional, 기본값 470px
  - width 값을 그대로 넘기기 때문에 단위도 작성해주셔야 합니다.
- `height`: string, optional, 기본값 155px
  - height값을 그대로 넘기기 때문에 단위도 작성해주셔야 합니다.

<br />

## 사용 방법(스토리북)
**_Default_**, props로 받는 width, height 값에 따른 변화입니다. 
![textarea default](https://user-images.githubusercontent.com/96400112/181712694-02a53548-6bdd-4ea6-baeb-75cb0a83d3c4.gif)

<br />

**_StyleCustom_**, style을 적용하는 방법입니다.
```typescript
export const StyleCustom = (args: TextareaProps) => (
  <Textarea
    placeholder="placeholder"
    style={{ width: "300px", padding: "20px", fontSize: "30px" }}
    {...args}
  />
);
```

<br />

**_WithState_**, `useState`를 사용하는 방법입니다.
![textarea withState](https://user-images.githubusercontent.com/96400112/181712778-e7b3a8cd-415c-4cb4-ab16-104042570649.gif)

<br />

**_WithRef_**, `useRef`를 사용하는 방법입니다.
![textarea withRef](https://user-images.githubusercontent.com/96400112/181712894-34bf7c0b-07cb-473e-9adc-52e7780348e1.gif)

<br />

**_resize: none_**, @NamgyungKim 리뷰 반영 완!
![image](https://user-images.githubusercontent.com/96400112/181717255-1feceffe-5946-4b48-a061-63a1e7d6c72a.png)


# 관련 이슈

<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->

- #13 이슈와 다른 점
  - `showLength`: boolean, optional, 기본값 `false`
    - `현재 작성된 글자 수/최대 글자 수` 표시 여부
    - 해당 기능(?)을 textarea 컴포넌트에서 같이 해주려고 구현하려고 생각했었는데, 구현할수록 `showLength=false`인 경우에는 필요하지 않은 값이나 함수를 가지고 있다는 점이 제 마음을 불편하게 하여 없애 버렸습니다.
    - `현재 작성된 글자 수/최대 글자 수` 표시를 보여주는 것은 페이지에서 처리하는 것이 좋을 것 같습니다.


<!-- closes #이슈번호 -->
closes #13 