### PR TITLE
Feature/#30-following

### DIFF
--- a/components/common/following.tsx
+++ b/components/common/following.tsx
@@ -3,17 +3,22 @@ import { color, text } from "@/styles/theme";
 import ProfileImage from "@/components/common/profileImage";
 import Button from "@/components/common/button";
 
-const Following = () => (
+export interface FollowingProps {
+  following: boolean;
+}
+
+const Following = ({ following, ...props }: FollowingProps) => (
   <Card>
     <ProfileImg size="md" />
     <UserName>Groot</UserName>
     <FollowingBtn
-      buttonType="small"
       colorType="skyblue"
       width="128"
       height="42"
+      buttonType={following ? "line" : "small"}
+      {...props}
     >
-      follow +
+      {following ? "following" : "follow +"}
     </FollowingBtn>
   </Card>
 );
@@ -26,7 +31,6 @@ const Card = styled.div`
   border-radius: 8px;
   box-shadow: 0px 0px 6px ${color.$gray400};
   display: flex;
-  /* justify-content: space-between; */
 `;
 
 const ProfileImg = styled(ProfileImage)`

--- a/components/common/following.tsx
+++ b/components/common/following.tsx
@@ -4,13 +4,14 @@ import ProfileImage from "@/components/common/profileImage";
 import Button from "@/components/common/button";
 
 export interface FollowingProps {
+  userName: string;
   following: boolean;
 }
 
-const Following = ({ following, ...props }: FollowingProps) => (
+const Following = ({ userName, following, ...props }: FollowingProps) => (
   <Card>
     <ProfileImg size="md" />
-    <UserName>Groot</UserName>
+    <UserName>{userName}</UserName>
     <FollowingBtn
       colorType="skyblue"
       width="128"

--- a/components/common/following.tsx
+++ b/components/common/following.tsx
@@ -1,0 +1,45 @@
+import styled from "@emotion/styled";
+import { color, text } from "@/styles/theme";
+import ProfileImage from "@/components/common/profileImage";
+import Button from "@/components/common/button";
+
+const Following = () => (
+  <Card>
+    <ProfileImg size="md" />
+    <UserName>Groot</UserName>
+    <FollowingBtn
+      buttonType="small"
+      colorType="skyblue"
+      width="128"
+      height="42"
+    >
+      follow +
+    </FollowingBtn>
+  </Card>
+);
+
+export default Following;
+
+const Card = styled.div`
+  height: 121px;
+  width: 400px;
+  border-radius: 8px;
+  box-shadow: 0px 0px 6px ${color.$gray400};
+  display: flex;
+  /* justify-content: space-between; */
+`;
+
+const ProfileImg = styled(ProfileImage)`
+  margin: auto 23px;
+`;
+
+const UserName = styled.div`
+  margin: auto;
+  margin-left: 0;
+  ${text.$headline5};
+`;
+
+const FollowingBtn = styled(Button)`
+  margin: auto 23px;
+  margin-left: 0;
+`;

--- a/components/common/following.tsx
+++ b/components/common/following.tsx
@@ -4,13 +4,22 @@ import ProfileImage from "@/components/common/profileImage";
 import Button from "@/components/common/button";
 
 export interface FollowingProps {
+  profileImg?: string;
   userName: string;
   following: boolean;
 }
 
-const Following = ({ userName, following, ...props }: FollowingProps) => (
+const Following = ({
+  profileImg,
+  userName,
+  following,
+  ...props
+}: FollowingProps) => (
   <Card>
-    <ProfileImg size="md" />
+    <ProfileImg
+      size="md"
+      src={profileImg || "/image/default-profile-image.png"}
+    />
     <UserName>{userName}</UserName>
     <FollowingBtn
       colorType="skyblue"

--- a/stories/components/following.stories.tsx
+++ b/stories/components/following.stories.tsx
@@ -1,9 +1,11 @@
-import Following from "@/components/common/following";
+import Following, { FollowingProps } from "@/components/common/following";
 
 export default {
   title: "components/Following",
   component: Following,
-  argTypes: {},
+  argTypes: {
+    following: { control: "boolean", defaultValue: false },
+  },
 };
 
-export const Default = () => <Following />;
+export const Default = (args: FollowingProps) => <Following {...args} />;

--- a/stories/components/following.stories.tsx
+++ b/stories/components/following.stories.tsx
@@ -1,0 +1,9 @@
+import Following from "@/components/common/following";
+
+export default {
+  title: "components/Following",
+  component: Following,
+  argTypes: {},
+};
+
+export const Default = () => <Following />;

--- a/stories/components/following.stories.tsx
+++ b/stories/components/following.stories.tsx
@@ -4,6 +4,7 @@ export default {
   title: "components/Following",
   component: Following,
   argTypes: {
+    userName: { control: { type: "text" }, defaultValue: "username" },
     following: { control: "boolean", defaultValue: false },
   },
 };

--- a/stories/components/following.stories.tsx
+++ b/stories/components/following.stories.tsx
@@ -4,6 +4,7 @@ export default {
   title: "components/Following",
   component: Following,
   argTypes: {
+    profileImg: { control: "text" },
     userName: { control: { type: "text" }, defaultValue: "username" },
     following: { control: "boolean", defaultValue: false },
   },

--- a/stories/components/following.stories.tsx
+++ b/stories/components/following.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Following,
   argTypes: {
     profileImg: { control: "text" },
-    userName: { control: { type: "text" }, defaultValue: "username" },
+    userName: { control: "text", defaultValue: "username" },
     following: { control: "boolean", defaultValue: false },
   },
 };


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요
following 카드 컴포넌트 구현
<!-- 간략 설명 -->

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->

https://user-images.githubusercontent.com/67778677/181887419-841cb8f1-952f-4da0-b941-f0a956aab5be.mov


# 중점적으로 봐줬으면 하는 부분 (선택 사항)

<!-- 선택사항 사용하지 않을시 제거부탁드려요 -->
props는 다음 3개를 받습니다.
 1. 프로필 이미지(url)
 2. user name(text)
 3. 팔로우 여부(boolean)

following 카드를 컴포넌트로 구현하는게 맞는지 의문이 들었습니다.
following 버튼으로 컴포넌트를 나누는게 더 나을까라는 생각이 들었어요,,
따라서 옆에 있던 효니와 이야기 나눠보고 일단은 기능 없이 props 받도록 디자인만 구현해봤습니다!

<!-- closes #이슈번호 -->
closes #30 
