### PR TITLE
Feature/#52-errorText

### DIFF
--- a/components/common/errorText.tsx
+++ b/components/common/errorText.tsx
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+import * as theme from "@/styles/theme";
+
+const ErrorText = styled.span`
+  display: inline-block;
+  white-space: pre-wrap;
+  ${theme.text.$caption};
+  color: ${theme.color.$warning};
+`;
+
+export default ErrorText;

--- a/stories/components/errorText.stories.tsx
+++ b/stories/components/errorText.stories.tsx
@@ -1,0 +1,34 @@
+import ErrorText from "@/components/common/errorText";
+import { HTMLAttributes } from "react";
+
+export default {
+  title: "Components/ErrorText",
+  component: ErrorText,
+  argTypes: {
+    children: { control: { type: "text" }, defaultValue: "햄치즈양상추" },
+  },
+};
+
+export const Default = ({
+  children,
+  ...args
+}: HTMLAttributes<HTMLSpanElement>) => (
+  <div style={{ width: "200px" }}>
+    <div>빵</div>
+    <ErrorText {...args}>{children}</ErrorText>
+    <div>빵</div>
+  </div>
+);
+
+export const Long = (args: HTMLAttributes<HTMLSpanElement>) => (
+  <div style={{ width: "200px", border: "1px solid brown" }}>
+    <div>빵</div>
+    <ErrorText {...args}>
+      햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄햄
+    </ErrorText>
+    <div>빵</div>
+  </div>
+);
+Long.parameters = {
+  controls: { exclude: "children" },
+};


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [ ] errorText 공통 컴포넌트 구현
# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- styled.span으로 span의 속성 모두 사용 가능합니다.
- 텍스트가 없을 때, 높이가 1줄 높이로 유지됩니다.

## 스토리북
**_Default_**
```js
<ErrorText>에러 문구</ErrorText>
```
![errorText default](https://user-images.githubusercontent.com/96400112/182068421-13579bee-e2a2-4486-8a72-0e8755d648f1.gif)

**_Long_**
![image](https://user-images.githubusercontent.com/96400112/182068439-121bdfe3-fab8-470b-b391-96e1a7c3c259.png)

<!-- closes #이슈번호 -->
closes #52 