### PR TITLE
Fix/#61-user info

### DIFF
--- a/components/common/userInfo.tsx
+++ b/components/common/userInfo.tsx
@@ -47,7 +47,6 @@ const UserInfo = ({ data }: UserInfoProps) => {
 
 const Card = styled.div`
   width: 277px;
-  height: 245px;
 `;
 
 const GridWrapper = styled.div`
@@ -87,7 +86,9 @@ const Bio = styled.div`
   max-height: 105px;
   width: 261px;
   margin: 10px;
+  padding: 10px 0;
   overflow-y: auto;
+  word-wrap: break-word;
 
   &::-webkit-scrollbar {
     width: 11px;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요
userInfo 공통 컴포넌트 레이아웃 수정했습니다.
<!-- 간략 설명 -->

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
<img width="303" alt="image" src="https://user-images.githubusercontent.com/67778677/182103629-2e77b01c-8e17-4871-a2d2-1930c4eb2891.png">

1. card 태그의 `height` 속성 삭제
2. bio 태그에 `padding` 속성 추가
3. bio 태그에 `word-wrap` 속성 추가



<!-- closes #이슈번호 -->
closes #61 