### PR TITLE
Feature/#51 signup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,8 @@
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "arrow-body-style": "off",
+    "@typescript-eslint/no-misused-promises": "off",
+    "@typescript-eslint/no-floating-promises": "off",
     "import/extensions": [
       "error",
       "ignorePackages",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,14 @@
   ],
   "rules": {
     "react/react-in-jsx-scope": "off",
+    "jsx-a11y/anchor-is-valid": [
+      "error",
+      {
+        "components": ["Link"],
+        "specialLink": ["hrefLeft", "hrefRight"],
+        "aspects": ["invalidHref", "preferButton"]
+      }
+    ],
     "react/jsx-filename-extension": [
       1,
       { "extensions": [".js", ".jsx", ".ts", ".tsx"] }

--- a/components/common/categoryItem.tsx
+++ b/components/common/categoryItem.tsx
@@ -14,7 +14,6 @@ const CategoryItem = ({ name, on, onChange, ...props }: CategoryItemProps) => {
   const [checked, toggle] = useToggle(on);
   const { color, fileName } = CATEGORY_MAP[name];
   const imgSrc = `/icon/category/${fileName}${checked ? "-selected" : ""}.svg`;
-  console.log(imgSrc);
 
   const handleChange: HandleChange = (e) => {
     toggle();

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -1,0 +1,16 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NEXTAUTH_URL: string;
+      GOOGLE_ID: string;
+      GOOGLE_SECRET: string;
+      NAVER_ID: string;
+      NAVER_SECRET: string;
+      KAKAO_ID: string;
+      KAKAO_SECRET: string;
+      END_POINT: string;
+    }
+  }
+}
+
+export {};

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -8,6 +8,10 @@ import styled from "@emotion/styled";
 import Link from "next/link";
 import { ChangeEventHandler, FormEvent, useCallback, useState } from "react";
 import { usernameRegExp } from "@/utils/validation";
+import Head from "next/head";
+import * as theme from "@/styles/theme";
+import axios from "axios";
+import { useRouter } from "next/router";
 
 type ChangeInputHandler = ChangeEventHandler<HTMLInputElement>;
 type CategoryType = typeof CATEGORY[number];
@@ -21,6 +25,10 @@ const SignUp = () => {
     value: [],
     errorText: "1개 이상 선택해주세요.",
   });
+  const [username, setUsername] = useState({ value: "", errorText: "" });
+
+  const router = useRouter();
+
   const getNextUserCategoryValue = useCallback(
     (selectedCategory: CategoryType) => {
       const hasSelectedCategory = userCategory.value.includes(selectedCategory);
@@ -31,6 +39,7 @@ const SignUp = () => {
     },
     [userCategory.value]
   );
+
   const handleCategoryClick: ChangeInputHandler = (e) => {
     const selectedCategory = e.target.name as CategoryType;
     const nextValue = getNextUserCategoryValue(selectedCategory);
@@ -39,8 +48,6 @@ const SignUp = () => {
       errorText: nextValue.length > 0 ? "" : "1개 이상 선택해주세요.",
     });
   };
-
-  const [username, setUsername] = useState({ value: "", errorText: "" });
   const handleUsernameChange: ChangeInputHandler = (e) => {
     const nextValue = e.target.value;
     setUsername({
@@ -50,82 +57,88 @@ const SignUp = () => {
         : "유저 네임은 2-6자의 한글, 영어, 숫자만 사용 가능합니다.",
     });
   };
-
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
 
-    // TODO: API 연결 및 유저 네임 중복 에러 메시지 설정
-    alert(
-      `submit\n선호 카테고리: ${userCategory.value.join(" ")}\n유저 네임: ${
-        username.value
-      }`
-    );
+    // TODO: 유저 네임 중복 에러 메시지 설정
+    // API 요청 테스트 필요
+    // signup({ username: username.value, category: userCategory.value });
+  };
+
+  const signup = async (body: {
+    username: string;
+    category: CategoryType[];
+  }) => {
+    try {
+      await axios.post(`${process.env.END_POINT}/api/v1/profiles`, body);
+      router.push("/my/favorite");
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
-    <Layout>
-      <h1>
-        <Link href="/" passHref>
-          <a>
-            <img
-              src="/icon/logo.svg"
-              alt="Link Ocean"
-              width={357}
-              height={57}
+    <>
+      <Head>
+        <title>LinkOcean | 회원가입</title>
+      </Head>
+      <Layout>
+        <h1>
+          <img src="/icon/logo.svg" alt="Link Ocean" width={357} height={57} />
+        </h1>
+
+        <Form onSubmit={handleSubmit}>
+          <CategorySection>
+            <Label style={{ marginBottom: "22px" }}>선호 카테고리 선택</Label>
+            <CategoryContainer>
+              {CATEGORY.map((category) => (
+                <CategoryItem
+                  name={category}
+                  onChange={handleCategoryClick}
+                  key={category}
+                />
+              ))}
+            </CategoryContainer>
+            <ErrorText style={{ height: "14px" }}>
+              {userCategory.errorText}
+            </ErrorText>
+          </CategorySection>
+
+          <UsernameSection>
+            <Label style={{ marginBottom: "6px" }}>유저 네임</Label>
+            <Input
+              type="text"
+              value={username.value}
+              onChange={handleUsernameChange}
             />
-          </a>
-        </Link>
-      </h1>
 
-      <Form onSubmit={handleSubmit}>
-        <CategorySection>
-          <Label style={{ marginBottom: "22px" }}>선호 카테고리 선택</Label>
-          <CategoryContainer>
-            {CATEGORY.map((category) => (
-              <CategoryItem
-                name={category}
-                onChange={handleCategoryClick}
-                key={category}
-              />
-            ))}
-          </CategoryContainer>
-          <ErrorText style={{ height: "14px" }}>
-            {userCategory.errorText}
-          </ErrorText>
-        </CategorySection>
+            <ErrorText style={{ marginTop: "5px", height: "14px" }}>
+              {username.errorText}
+            </ErrorText>
+          </UsernameSection>
 
-        <UsernameSection>
-          <Label style={{ marginBottom: "6px" }}>유저 네임</Label>
-          <Input
-            type="text"
-            value={username.value}
-            onChange={handleUsernameChange}
-          />
+          <StyledButton
+            type="submit"
+            buttonType="small"
+            colorType="main-color"
+            width="175"
+            style={{ margin: "63px auto 0" }}
+            disabled={
+              // TODO:닉네임 중복일 때 조건 추가 필요
+              userCategory.errorText !== "" ||
+              username.errorText !== "" ||
+              username.value === ""
+            }
+          >
+            회원 가입
+          </StyledButton>
 
-          <ErrorText style={{ marginTop: "5px", height: "14px" }}>
-            {username.errorText}
-          </ErrorText>
-        </UsernameSection>
-
-        <Button
-          type="submit"
-          buttonType="small"
-          colorType="main-color"
-          width="175"
-          style={{ margin: "63px auto 0" }}
-          disabled={
-            userCategory.errorText !== "" ||
-            username.errorText !== "" ||
-            username.value === ""
-          }
-        >
-          회원 가입
-        </Button>
-      </Form>
-
-      <Test>선택된 선호 카테고리: {userCategory.value.join(" ")}</Test>
-      <Test>유저 네임: {username.value}</Test>
-    </Layout>
+          <Link href="/" passHref>
+            <LinkText>이미 다른 계정이 있나요? 로그인하러 가기</LinkText>
+          </Link>
+        </Form>
+      </Layout>
+    </>
   );
 };
 
@@ -163,6 +176,18 @@ const UsernameSection = styled.section`
   justify-content: flex-start;
 `;
 
-const Test = styled.div``;
+const StyledButton = styled(Button)`
+  &:disabled {
+    background-color: ${theme.color.$mainColor};
+    cursor: not-allowed;
+  }
+`;
+
+const LinkText = styled.a`
+  display: block;
+  margin: 9px auto 0;
+  color: ${theme.color.$gray600};
+  ${theme.text.$caption};
+`;
 
 export default SignUp;

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -5,38 +5,126 @@ import Input from "@/components/common/input";
 import Label from "@/components/common/label";
 import { CATEGORY } from "@/types/type";
 import styled from "@emotion/styled";
+import Link from "next/link";
+import { ChangeEventHandler, FormEvent, useCallback, useState } from "react";
+import { usernameRegExp } from "@/utils/validation";
+
+type ChangeInputHandler = ChangeEventHandler<HTMLInputElement>;
+type CategoryType = typeof CATEGORY[number];
+type UserCategory = {
+  value: CategoryType[];
+  errorText: string;
+};
 
 const SignUp = () => {
+  const [userCategory, setUserCategory] = useState<UserCategory>({
+    value: [],
+    errorText: "1개 이상 선택해주세요.",
+  });
+  const getNextUserCategoryValue = useCallback(
+    (selectedCategory: CategoryType) => {
+      const hasSelectedCategory = userCategory.value.includes(selectedCategory);
+
+      return hasSelectedCategory
+        ? userCategory.value.filter((category) => category !== selectedCategory)
+        : [...userCategory.value, selectedCategory];
+    },
+    [userCategory.value]
+  );
+  const handleCategoryClick: ChangeInputHandler = (e) => {
+    const selectedCategory = e.target.name as CategoryType;
+    const nextValue = getNextUserCategoryValue(selectedCategory);
+    setUserCategory({
+      value: nextValue,
+      errorText: nextValue.length > 0 ? "" : "1개 이상 선택해주세요.",
+    });
+  };
+
+  const [username, setUsername] = useState({ value: "", errorText: "" });
+  const handleUsernameChange: ChangeInputHandler = (e) => {
+    const nextValue = e.target.value;
+    setUsername({
+      value: nextValue,
+      errorText: usernameRegExp.test(nextValue)
+        ? ""
+        : "유저 네임은 2-6자의 한글, 영어, 숫자만 사용 가능합니다.",
+    });
+  };
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+
+    // TODO: API 연결 및 유저 네임 중복 에러 메시지 설정
+    alert(
+      `submit\n선호 카테고리: ${userCategory.value.join(" ")}\n유저 네임: ${
+        username.value
+      }`
+    );
+  };
+
   return (
     <Layout>
-      <img src="/icon/logo.svg" alt="Link Ocean" width={357} height={57} />
+      <h1>
+        <Link href="/" passHref>
+          <a>
+            <img
+              src="/icon/logo.svg"
+              alt="Link Ocean"
+              width={357}
+              height={57}
+            />
+          </a>
+        </Link>
+      </h1>
 
-      <CategoryForm>
-        <Label style={{ marginBottom: "22px" }}>선호 카테고리 선택</Label>
-        <CategoryContainer>
-          {CATEGORY.map((category) => (
-            <CategoryItem name={category} />
-          ))}
-        </CategoryContainer>
-        <ErrorText>1개 이상 선택해주세요.</ErrorText>
-      </CategoryForm>
+      <Form onSubmit={handleSubmit}>
+        <CategorySection>
+          <Label style={{ marginBottom: "22px" }}>선호 카테고리 선택</Label>
+          <CategoryContainer>
+            {CATEGORY.map((category) => (
+              <CategoryItem
+                name={category}
+                onChange={handleCategoryClick}
+                key={category}
+              />
+            ))}
+          </CategoryContainer>
+          <ErrorText style={{ height: "14px" }}>
+            {userCategory.errorText}
+          </ErrorText>
+        </CategorySection>
 
-      <UsernameForm>
-        <Label style={{ marginBottom: "6px" }}>유저 네임</Label>
-        <Input type="text" />
-        <ErrorText style={{ marginTop: "5px" }}>
-          해당 유저 네임이 존재합니다.
-        </ErrorText>
-      </UsernameForm>
+        <UsernameSection>
+          <Label style={{ marginBottom: "6px" }}>유저 네임</Label>
+          <Input
+            type="text"
+            value={username.value}
+            onChange={handleUsernameChange}
+          />
 
-      <Button
-        buttonType="small"
-        colorType="main-color"
-        width="175"
-        style={{ margin: "63px auto 0" }}
-      >
-        회원 가입
-      </Button>
+          <ErrorText style={{ marginTop: "5px", height: "14px" }}>
+            {username.errorText}
+          </ErrorText>
+        </UsernameSection>
+
+        <Button
+          type="submit"
+          buttonType="small"
+          colorType="main-color"
+          width="175"
+          style={{ margin: "63px auto 0" }}
+          disabled={
+            userCategory.errorText !== "" ||
+            username.errorText !== "" ||
+            username.value === ""
+          }
+        >
+          회원 가입
+        </Button>
+      </Form>
+
+      <Test>선택된 선호 카테고리: {userCategory.value.join(" ")}</Test>
+      <Test>유저 네임: {username.value}</Test>
     </Layout>
   );
 };
@@ -51,7 +139,12 @@ const Layout = styled.div`
   height: 100%;
 `;
 
-const CategoryForm = styled.form`
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+`;
+
+const CategorySection = styled.section`
   display: flex;
   flex-direction: column;
   margin: 102px 0 75px;
@@ -61,15 +154,15 @@ const CategoryContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 30px;
-  width: 790px;
   margin-bottom: 11px;
 `;
 
-const UsernameForm = styled.form`
+const UsernameSection = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  width: 790px;
 `;
+
+const Test = styled.div``;
 
 export default SignUp;

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,75 @@
+import Button from "@/components/common/button";
+import CategoryItem from "@/components/common/categoryItem";
+import ErrorText from "@/components/common/errorText";
+import Input from "@/components/common/input";
+import Label from "@/components/common/label";
+import { CATEGORY } from "@/types/type";
+import styled from "@emotion/styled";
+
+const SignUp = () => {
+  return (
+    <Layout>
+      <img src="/icon/logo.svg" alt="Link Ocean" width={357} height={57} />
+
+      <CategoryForm>
+        <Label style={{ marginBottom: "22px" }}>선호 카테고리 선택</Label>
+        <CategoryContainer>
+          {CATEGORY.map((category) => (
+            <CategoryItem name={category} />
+          ))}
+        </CategoryContainer>
+        <ErrorText>1개 이상 선택해주세요.</ErrorText>
+      </CategoryForm>
+
+      <UsernameForm>
+        <Label style={{ marginBottom: "6px" }}>유저 네임</Label>
+        <Input type="text" />
+        <ErrorText style={{ marginTop: "5px" }}>
+          해당 유저 네임이 존재합니다.
+        </ErrorText>
+      </UsernameForm>
+
+      <Button
+        buttonType="small"
+        colorType="main-color"
+        width="175"
+        style={{ margin: "63px auto 0" }}
+      >
+        회원 가입
+      </Button>
+    </Layout>
+  );
+};
+
+const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 8vw auto;
+  width: 790px;
+  height: 100%;
+`;
+
+const CategoryForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  margin: 102px 0 75px;
+`;
+
+const CategoryContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 30px;
+  width: 790px;
+  margin-bottom: 11px;
+`;
+
+const UsernameForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 790px;
+`;
+
+export default SignUp;

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,0 +1,3 @@
+export const usernameRegExp = /^[가-힣|a-z|A-Z|\d]{1,6}$/;
+
+export default {};

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,3 +1,3 @@
-export const usernameRegExp = /^[가-힣|a-z|A-Z|\d]{1,6}$/;
+export const usernameRegExp = /^[가-힣|a-z|A-Z|\d]{2,6}$/;
 
 export default {};


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

### 08/02 합체 데이를 위해 미리 PR를 작성했습니다. 이대로 merge 안 합니당!

# 개요

<!-- 간략 설명 -->
- [x] signup 페이지 UI 구현

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- [x] signup 페이지 API 연결 전까지 구현
- [x] `<a>` 요소에 `herf` 속성이 없을 때, 뜨는 eslint 규칙 좀 손 봤습니다. 
- [x] `CategoryItem` 컴포넌트에 있던 주석을 슬쩍 삭제했습니다.
- [x] 로고 클릭 시 "/" 페이지로 이동합니다. (우선 구현은 했는데 이 부분은 어떻게 처리할지 고민입니다.)
  -  alert 창으로 "회원 가입을 취소하시겠습니까?"
  - 왼쪽 상단에 뒤로 가기 버튼 추가(조이 아이디어)
  - `회원 가입` 버튼 밑에 "이미 다른 계정이 있나요? 로그인하러 가기" link 추가 (수경님 아이디어)
      ![image](https://user-images.githubusercontent.com/96400112/182175182-6e25ff33-e518-40f1-a14f-146848702d30.png)

## 선호 카테고리
- 카테고리 버튼을 클릭하여 선호 카테고리를 활성화/비활성화 할 수 있음
- 선택된 선호 카테고리의 개수가 0개인 경우 "1개 이상 선택해주세요." 에러 문구가 표시됨
- 코드에서 선택된 선호 카테고리의 배열 상태 === `userCategory.value`

## 유저 네임
- **검증**, 2-6자 이내 한글, 영어, 숫자만 가능

## 검증
![유저네임 검증](https://user-images.githubusercontent.com/96400112/182176879-9ca740ec-ae6f-4255-a6fe-d08f422ab7f2.gif)

## 데모
> 유저 네임 검증에서 정규 표현식이 1-6자로 설정되어 있는 상태일 때 촬영한 영상입니다..코드는 2-6자로 수정해서 올렸습니다!

https://user-images.githubusercontent.com/96400112/182162635-cbeb3a63-b018-4518-a939-3c462370f2bb.mp4

데모 영상에서 `회원 가입` 버튼이 disabled일 때 커서가 접근 불가로 변경되는 점은 제가 저는 disabled 속성을 좋아해서.. 임의로 button 코드를 고쳐서 촬영한 것입니다! (disabled일 때, hover 시 버튼 배경 색상이 변경되지 않고 커서가 not-allowed로 변경되었으면 합니다. :hover, :disabled 모두 가상 선택자라 inline style로 추가할 수 없습니다ㅠㅠ)

# 중점적으로 봐줬으면 하는 부분 (선택 사항)

<!-- 선택사항 사용하지 않을시 제거부탁드려요 -->
@NamgyungKim @jieun0411 @dbckdgjs369 
내일 합체데이라..모든 분들이 리뷰해주셨으면 해서 모두 태그했습니다 하하

<!-- closes #이슈번호 -->
closes #51 