### PR TITLE
Feature/#97-axiosConfig

### DIFF
--- a/utils/apis/instance.ts
+++ b/utils/apis/instance.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+import storage from "@/utils/localStorage";
+
+const baseURL = `${process.env.END_POINT}/api/v1`;
+
+const unauthInstance = axios.create({ baseURL });
+const authInstance = axios.create({ baseURL });
+authInstance.interceptors.request.use(
+  (config) => {
+    // eslint-disable-next-line no-param-reassign
+    config.headers = {
+      Authorization: `bearer ${storage.getItem("LINKOCEAN_TOKEN", "")}`,
+    };
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
+export { unauthInstance, authInstance };


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [x] axios 비인증, 인증 instance 생성

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- axios 비인증(`unauthInstance`), 인증(`authInstance`) 요청 분리
- axios 인증 instance 요청에는 axios interceptor를 활용하여, 요청 전 로컬 스토리지 내 jwt 토큰을 가져와 header에 담아 요청하도록 설정

<!-- closes #이슈번호 -->
closes #97 