### PR TITLE
Fix/#102-jwtTokenApi

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -6,16 +6,16 @@ import KakaoProvider from "next-auth/providers/kakao";
 export default NextAuth({
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_ID as string,
-      clientSecret: process.env.GOOGLE_SECRET as string,
+      clientId: process.env.GOOGLE_ID,
+      clientSecret: process.env.GOOGLE_SECRET,
     }),
     NaverProvider({
-      clientId: process.env.NAVER_ID as string,
-      clientSecret: process.env.NAVER_SECRET as string,
+      clientId: process.env.NAVER_ID,
+      clientSecret: process.env.NAVER_SECRET,
     }),
     KakaoProvider({
-      clientId: process.env.KAKAO_ID as string,
-      clientSecret: process.env.KAKAO_SECRET as string,
+      clientId: process.env.KAKAO_ID,
+      clientSecret: process.env.KAKAO_SECRET,
     }),
   ],
 });

--- a/utils/apis/profile.ts
+++ b/utils/apis/profile.ts
@@ -1,0 +1,21 @@
+import { ProfileDetail } from "@/types/model";
+import { CATEGORY } from "@/types/type";
+import { unauthInstance, authInstance } from "./instance";
+
+export type OauthType = "GOOGLE" | "NAVER" | "KAKAO";
+export type Login = { email: string; oauthType: OauthType };
+export type Profiles = {
+  username: string;
+  categories: typeof CATEGORY[number][];
+};
+
+const profileAPI = {
+  login: (payload: Login) =>
+    unauthInstance.post<{ token: string }>("/login", payload),
+  loginSuccess: () =>
+    authInstance.get<{ hasProfile: boolean }>("/login/success"),
+  profiles: (payload: Profiles) => authInstance.post("/profiles", payload),
+  profilesMe: () => authInstance.get<ProfileDetail>("/profiles/me"),
+};
+
+export default profileAPI;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [x] `로그인 API`를 미인증 axios instance으로 사용하도록 변경
- [x] `로그인 성공 API` 추가
- [x] `프로필 등록 API`를 인증 axios instance으로 사용하도록 변경

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 변경된 API를 사용하도록 로그인페이지, 회원가입 페이지 수정
- 회원가입 페이지
  - 중복된 유저 네임일 경우에 대한 에러 문구 추가

- 데모 마지막에 404 페이지가 뜨는 건, 회원가입 성공 시 my/favorite 페이지로 보내기 때문입니당.

https://user-images.githubusercontent.com/96400112/183040348-53832be3-41b9-4db2-922b-3ed6c171972d.mov

# 질문
- 회원가입 페이지로 넘어갈 때와 my/favorite 페이지로 넘어갈 때 알림(?)이나 토스트없이 이동하는 게 자연스러워 보이나요? 동영상으로 보니까 이상해 보이네요..?

<!-- closes #이슈번호 -->
closes #102 