### PR TITLE
Fix/#112-selectStyle

### DIFF
--- a/components/common/select/optionList.tsx
+++ b/components/common/select/optionList.tsx
@@ -27,6 +27,7 @@ const StyledList = styled.ul`
   border-radius: 0 0 8px 8px;
   padding: 8px 0;
   background-color: #fff;
+  z-index: 10;
   box-sizing: border-box;
   overflow-y: overlay;
 

--- a/components/common/select/select.tsx
+++ b/components/common/select/select.tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled";
 import Option from "./option";
 import OptionList from "./optionList";
 import SelectProvider, { SelectProviderProps } from "./selectStore";
@@ -17,10 +18,14 @@ const Select = ({
       selectedOption={selectedOption}
       onChange={onChange}
     >
-      {children}
+      <Container>{children}</Container>
     </SelectProvider>
   );
 };
+
+const Container = styled.div`
+  position: relative;
+`;
 
 Select.Trigger = Trigger;
 Select.OptionList = OptionList;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [x] select 공통 컴포넌트 레이아웃 깨짐 수정
# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->

- [x] z-index 설정 (@jieun0411)
- [x] div 감싸서 깨지지 않도록 설정 (@NamgyungKim)

조이의 create 페이지에서 실험해봤습니당
![image](https://user-images.githubusercontent.com/96400112/183158933-28c51fba-a134-452f-bd79-6b0cba45f24c.png)

![select fix](https://user-images.githubusercontent.com/96400112/183159191-39d87ca9-8723-4f14-8cc3-5b56d78e3bc0.gif)

<!-- closes #이슈번호 -->
closes #112 