### PR TITLE
Feature/#123-searchMeoguriPageLayout

### DIFF
--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -1,0 +1,137 @@
+import MyFilterMenu from "@/components/common/filterMenu/myFilterMenu";
+import Following from "@/components/common/following";
+import PageLayout from "@/components/common/pageLayout";
+import UserInfo from "@/components/common/userInfo";
+import { getProfile } from "@/types/dummyData";
+import styled from "@emotion/styled";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import * as theme from "@/styles/theme";
+import Input from "@/components/common/input";
+import Button from "@/components/common/button";
+import { ChangeEvent, FormEvent, useState, useEffect } from "react";
+import {
+  DUMMY_FOLLOWE,
+  DUMMY_USER_INFO,
+  FollowCardContainer,
+  Layout,
+} from "./my/follow";
+
+const PAGE_SIZE = 8;
+
+type Filtering = {
+  username: string;
+  page: number;
+  size: number;
+};
+
+const INITIAL_FILTERING: Filtering = {
+  username: "",
+  page: 1,
+  size: PAGE_SIZE,
+};
+
+const Meoguri = () => {
+  const router = useRouter();
+
+  const [state, setState] = useState(() => ({
+    ...INITIAL_FILTERING,
+    username: router.query.name ? (router.query.name as string) : "",
+  }));
+  const [profiles, setProfiles] = useState(DUMMY_FOLLOWE.profiles);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setState({ ...state, username: e.target.value });
+  };
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const trimmedUsername = state.username.trim();
+    const nextPath = trimmedUsername === "" ? "" : `?name=${trimmedUsername}`;
+    router.push(`/meoguri${nextPath}`);
+  };
+
+  useEffect(() => {
+    setState({ ...state, username: router.query.name as string });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.query.name]);
+
+  return (
+    <>
+      <Head>
+        <title>LinkOcean | 머구리 찾기</title>
+      </Head>
+
+      <PageLayout>
+        <PageLayout.Aside>
+          <UserInfo data={DUMMY_USER_INFO} />
+          <MyFilterMenu
+            tagList={getProfile.tags}
+            categoryList={getProfile.categories}
+            getCategoryData={() => {}}
+            getTagsData={() => {}}
+          />
+        </PageLayout.Aside>
+        <PageLayout.Article>
+          <Layout>
+            <Title>머구리 찾기</Title>
+
+            <Test>router {router.query.name}</Test>
+            <Test>상태 {JSON.stringify(state, null, " ")}</Test>
+            <Test>{`API queryString: ${new URLSearchParams(
+              Object.entries(state).map(([key, value]) => [
+                key,
+                value === undefined ? "" : value.toString(),
+              ])
+            ).toString()}`}</Test>
+
+            <Form onSubmit={handleSubmit}>
+              <Input
+                searchIcon
+                name="name"
+                width="400px"
+                value={state.username}
+                onChange={handleChange}
+              />
+              <Button
+                colorType="main-color"
+                buttonType="small"
+                type="submit"
+                width="67"
+              >
+                검색
+              </Button>
+            </Form>
+
+            <FollowCardContainer>
+              {profiles.map(({ profileId, imageUrl, isFollow, username }) => (
+                <Following
+                  profileImg={imageUrl}
+                  userName={username}
+                  following={isFollow}
+                  key={profileId}
+                />
+              ))}
+            </FollowCardContainer>
+          </Layout>
+        </PageLayout.Article>
+      </PageLayout>
+    </>
+  );
+};
+
+const Title = styled.h2`
+  margin: 10px 0 29px 4px;
+  color: ${theme.color.$gray800};
+  ${theme.text.$headline5};
+`;
+
+const Form = styled.form`
+  display: flex;
+  gap: 10px;
+  margin-bottom: 37px;
+`;
+
+const Test = styled.div``;
+
+export default Meoguri;

--- a/pages/my/follow.tsx
+++ b/pages/my/follow.tsx
@@ -59,7 +59,7 @@ const Follow = () => {
   );
 };
 
-const Layout = styled.div`
+export const Layout = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -72,7 +72,7 @@ const Form = styled.form`
   text-align: center;
 `;
 
-const FollowCardContainer = styled.div`
+export const FollowCardContainer = styled.div`
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
@@ -82,9 +82,9 @@ const FollowCardContainer = styled.div`
 
 export default Follow;
 
-const { isFollow, ...DUMMY_USER_INFO } = getProfile;
+export const { isFollow, ...DUMMY_USER_INFO } = getProfile;
 
-const DUMMY_FOLLOWE = {
+export const DUMMY_FOLLOWE = {
   profiles: [
     {
       profileId: 1,


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [x] 머구리찾기 페이지 레이아웃

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- [x] 머구리찾기 페이지 레이아웃
- [x] API 요청에 사용할 `username`,`page`, `size` 상태 관리
- [x] `username` 상태와 url 동기화 

![meoguri](https://user-images.githubusercontent.com/96400112/183254551-34b2c7bb-2b3e-4bbb-a54c-42e44268b849.gif)

# 관련 이슈

<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->
## 아직 구현되지 않은 기능들
- [ ] 잘못된 query string일 때 404페이지로 보내기
- [ ] 다른 페이지로 이동
- [ ] API 연결
- [ ] 무한스크롤
- [ ] 검색 결과 없을 때 UI (#128 에서 검색 결과 없을 때 사용할 해마가 올라올 것 같아 기다리기로!)
- [ ] 로딩 UI

<!-- closes #이슈번호 -->
closes #123 