### PR TITLE
Feature/#147-feedPageAPI

### DIFF
--- a/utils/queryString.ts
+++ b/utils/queryString.ts
@@ -1,0 +1,6 @@
+export const getQueryString = (obj: object) =>
+  Object.entries(obj)
+    .map((entry) => entry.join("="))
+    .join("&");
+
+export default getQueryString;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- `피드 북마크 목록 조회 API` 연결

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- `피드 북마크 목록 조회 API` 연결
- 객체를 queryString으로 만드는 유틸 함수(`getQueryString`) 추가
- 필터링 조건(=`state`) 변경 시 브라우저 URL에도 반영
- 피드 페이지 폴더 구조 변경 "/pages/feed/[[...query]].tsx" 👉🏼 "/pages/feed/index.tsx"

## 데모
- 현재 `피드 북마크 목록 조회 API`가 사용만 가능하고, 개발이 완료된 API가 아니라 query를 요청 body에 넣어도 동일한 값을 응답으로 내려주기 때문에 화면 단에서 북마크 목록이 변경되지 않고 있습니다.

https://user-images.githubusercontent.com/96400112/183308241-9f82490c-1291-4b7b-9fdb-fc2c477d55f8.mp4


# 관련 이슈

<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->

## 아직 구현되지 않은 기능들
- 새로 고침 시 url query로 필터링 상태(=`state`)를 동기화하는 작업은 아직 안 함
- 유효하지 않은 url일 시 404페이지 보내기
- 로딩

# 중점적으로 봐줬으면 하는 부분 (선택 사항)

<!-- 선택사항 사용하지 않을시 제거부탁드려요 -->
- 필터링 조건은 총 5개로 `카테고리`, `페이지네이션`, `검색어`, `팔로워 게시글만`, `정렬 순서`가 있습니다. 각 항목의 값이 변경될 때마다 다른 항목의 값을 초기화해야 하는 값들이 있어 초기화했습니다.
**초기화되는 항목들이 보기에 자연스러운지 궁금합니다.**
  | 변경된 항목 | 초기화되는 항목들|
  |-|-|
  |카테고리|검색어, 페이지네이션|
  |페이지네이션|X|
  |검색어|페이지네이션|
  |팔로워 게시글만|페이지네이션|
  |정렬 순서|페이지네이션|



<!-- closes #이슈번호 -->
closes #147 