### PR TITLE
Feature/#149-myFollowPageInfiniteScroll

### DIFF
--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+interface UseIntersectionObserverProps {
+  root?: null;
+  rootMargin?: string;
+  threshold?: number;
+  onIntersect: IntersectionObserverCallback;
+}
+
+const useIntersectionObserver = ({
+  root,
+  rootMargin = "0px",
+  threshold = 0,
+  onIntersect,
+}: UseIntersectionObserverProps) => {
+  const [target, setTarget] = useState<HTMLElement | null | undefined>(null);
+
+  useEffect(() => {
+    if (!target) return;
+
+    const observer: IntersectionObserver = new IntersectionObserver(
+      onIntersect,
+      { root, rootMargin, threshold }
+    );
+    observer.observe(target);
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      observer.disconnect();
+    };
+  }, [onIntersect, root, rootMargin, target, threshold]);
+
+  return { setTarget };
+};
+
+export default useIntersectionObserver;

--- a/pages/my/follow.tsx
+++ b/pages/my/follow.tsx
@@ -10,9 +10,13 @@ import { useCallback, useEffect, useState } from "react";
 import { Profile } from "@/types/model";
 import profileAPI from "@/utils/apis/profile";
 import { useRouter } from "next/router";
+import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+import { getQueryString } from "@/utils/queryString";
 
 // TODO: 팔로우 하기, 언팔로우 하기, 전역 유저 정보, 라우팅
 const PAGE_SIZE = 8;
+const isLastCard = (index: number, length: number) =>
+  index === Math.max(0, length - 1);
 
 type Filtering = {
   tab: "follower" | "followee";
@@ -30,26 +34,63 @@ const Follow = () => {
   const [tempUser, setTempUser] = useState(DUMMY_USER.HYONI); // 유저 context로 대체될 코드
 
   const [state, setState] = useState(INITIAL_FILTERING);
-  const [followProfiles, setFollowProfiles] = useState<Profile[]>([]);
+  const [followProfiles, setFollowProfiles] = useState<{
+    value: Profile[];
+    isLoading: boolean;
+  }>({ value: [], isLoading: false });
+  const [isEndPage, setIsEndPage] = useState(false);
 
   const handleChange = (type: string, value: string | number) => {
-    setState({ ...state, [type]: value });
+    setState({ ...state, [type]: value, page: INITIAL_FILTERING.page });
+    setIsEndPage(false);
   };
 
   const getFollowProfiles = useCallback(async () => {
     const { profileId } = tempUser;
     const { tab, ...query } = state;
-    const queryString = Object.entries(query)
-      .map((entry) => entry.join("="))
-      .join("&");
+    const queryString = getQueryString(query);
 
     try {
-      const response = await profileAPI.getFollow(profileId, tab, queryString);
-      setFollowProfiles(response.data.profiles);
+      setFollowProfiles(({ value }) => ({ value, isLoading: true }));
+
+      const {
+        data: { profiles },
+      } = await profileAPI.getFollow(profileId, tab, queryString);
+
+      if (profiles.length === 0 || profiles.length < query.size) {
+        setIsEndPage(true);
+      }
+
+      setFollowProfiles(({ value }) => {
+        const nextValue =
+          query.page === INITIAL_FILTERING.page
+            ? profiles
+            : [...value, ...profiles];
+
+        return {
+          value: nextValue,
+          isLoading: false,
+        };
+      });
     } catch (error) {
       console.error(error);
     }
   }, [state, tempUser]);
+
+  const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
+    if (isEndPage) {
+      setTarget(undefined);
+      return;
+    }
+
+    if (isIntersecting && !followProfiles.isLoading) {
+      setState({ ...state, page: state.page + 1 });
+    }
+  };
+  const { setTarget } = useIntersectionObserver({
+    onIntersect,
+    threshold: 0.8,
+  });
 
   useEffect(() => {
     getFollowProfiles();
@@ -77,28 +118,6 @@ const Follow = () => {
         </PageLayout.Aside>
         <PageLayout.Article>
           <Layout>
-            <Test>{JSON.stringify(state, null, " ")}</Test>
-            <Test>
-              {new URLSearchParams(
-                Object.entries(state).map(([key, value]) => [
-                  key,
-                  value.toString(),
-                ])
-              ).toString()}
-            </Test>
-            <button
-              type="button"
-              onClick={() => {
-                setTempUser(
-                  tempUser.username === "효니"
-                    ? DUMMY_USER.MEOGURI
-                    : DUMMY_USER.HYONI
-                );
-              }}
-            >
-              {tempUser.username === "효니" ? "머구리" : "효니"}로 변경
-            </button>
-
             <Form>
               <FollowRadio
                 name="follow"
@@ -119,15 +138,24 @@ const Follow = () => {
                 }}
               />
             </Form>
+
             <FollowCardContainer>
-              {followProfiles.map(
-                ({ profileId, imageUrl, isFollow, username }) => (
-                  <Following
-                    profileImg={imageUrl}
-                    userName={username}
-                    following={isFollow}
-                    key={profileId}
-                  />
+              {followProfiles.value.map(
+                ({ profileId, imageUrl, isFollow, username }, index) => (
+                  <div
+                    ref={
+                      isLastCard(index, followProfiles.value.length)
+                        ? setTarget
+                        : null
+                    }
+                  >
+                    <Following
+                      profileImg={imageUrl}
+                      userName={username}
+                      following={isFollow}
+                      key={profileId}
+                    />
+                  </div>
                 )
               )}
             </FollowCardContainer>
@@ -159,24 +187,22 @@ export const FollowCardContainer = styled.div`
   width: 835px;
 `;
 
-const Test = styled.div``;
-
 export default Follow;
 
 const DUMMY_USER = {
   HYONI: {
-    profileId: 6,
+    profileId: 3,
     imageUrl: null,
     favoriteCategories: ["여행"],
     username: "효니",
     bio: null,
-    followerCount: 1,
-    followeeCount: 1,
+    followerCount: 4,
+    followeeCount: 0,
     tags: [],
     categories: [],
   },
   MEOGURI: {
-    profileId: 18,
+    profileId: 5,
     imageUrl: null,
     favoriteCategories: ["IT"],
     username: "머구리",


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [x] 마이페이지 팔로워/팔로잉 무한스크롤 구현

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- useIntersectionObserver 훅 추가
  - 매개변수
    - `onIntersect`: IntersectionObserver 생성자의 callback 매개변수로 전달될 콜백 함수
    - `root, rootMargin, threshold`: IntersectionObserver 생성자의 options로 전달될 설정 값들
  - 반환값
    - `setTarget`: 생성된 IntersectionObserver의 인스턴스의 target(=관찰 대상)을 설정
- 마이페이지 팔로워/팔로잉에서 useIntersectionObserver 훅을 사용하여 무한 스크롤 기능 구현
- 기타
  - 백엔드 DB 초기화로 인해 변경된 효니와 머구리의 유저 정보(더미) 업데이트
  - 이전 PR을 위해 남겨둔 사용자를 변경하는 (효니 <-> 머구리) 버튼 제거
  - 테스트용 코드 제거

## 데모
> 팔로워 수가 많지 않다 보니, 데모 환경에서는 "팔로워/팔로잉 전체 조회 API" 요청 시 "한 번에 불러올 프로필 개수"를 1로 설정하고 브라우저 뷰포트에 Follow 컴포넌트가 1개만 보이도록 레이아웃을 건드려서 진행했습니다. 

> 또한 관찰 대상을 쉽게 확인할 수 있게 빨간 border를 설정했습니다!

https://user-images.githubusercontent.com/96400112/183481462-9f2c4808-4631-4fa3-b93b-e8d71c547bb6.mp4


# 관련 이슈

<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->

- 팔로워 수를 늘려 무한 스크롤의 동작이 자연스럽게 보이는 지 확인이 필요할 것 같습니다

<!-- closes #이슈번호 -->
closes #149 