### PR TITLE
Feature/#168-머구리찾기 페이지 무한 스크롤 + URL 동기화

### DIFF
--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -9,19 +9,15 @@ import { useRouter } from "next/router";
 import * as theme from "@/styles/theme";
 import Input from "@/components/common/input";
 import Button from "@/components/common/button";
-import {
-  ChangeEvent,
-  FormEvent,
-  useState,
-  useEffect,
-  useCallback,
-} from "react";
+import { FormEvent, useState, useEffect, useCallback } from "react";
 import profileAPI from "@/utils/apis/profile";
 import { Profile } from "@/types/model";
+import { getQueryString } from "@/utils/queryString";
+import useIntersectionObserver from "../hooks/useIntersectionObserver";
 import {
-  DUMMY_FOLLOWE,
   DUMMY_USER_INFO,
   FollowCardContainer,
+  isLastCard,
   Layout,
 } from "./my/follow";
 
@@ -46,52 +42,85 @@ const Meoguri = () => {
 
   const [state, setState] = useState(INITIAL_FILTERING);
   const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [usernameInputValue, setUsernameInputValue] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isEndPage, setIsEndPage] = useState(false);
 
-  const getProfiles = useCallback(
-    async (username: string) => {
-      setIsLoading(true);
+  const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
+    if (isEndPage) {
+      setTarget(undefined);
+      return;
+    }
 
-      const queryString = `username=${username}&page=${state.page}&size=${state.size}`;
+    if (isIntersecting && !isLoading) {
+      setState({ ...state, page: state.page + 1 });
+    }
+  };
+  const { setTarget } = useIntersectionObserver({
+    onIntersect,
+    threshold: 0.8,
+  });
 
-      try {
-        const response = await profileAPI.getProfilesByUsername(queryString);
-        setProfiles(response.data.profiles);
-      } catch (error) {
-        console.error(error);
+  const getProfiles = useCallback(async () => {
+    if (state.username === "") {
+      return;
+    }
+    setIsLoading(true);
+
+    const queryString = getQueryString(state);
+
+    try {
+      const response = await profileAPI.getProfilesByUsername(queryString);
+      const responseProfiles = response.data.profiles;
+
+      if (
+        responseProfiles.length === 0 ||
+        responseProfiles.length < state.size
+      ) {
+        setIsEndPage(true);
       }
 
-      setIsLoading(false);
-    },
-    [state.page, state.size]
-  );
+      setProfiles((prevProfiles) =>
+        state.page === 1
+          ? responseProfiles
+          : [...prevProfiles, ...responseProfiles]
+      );
+    } catch (error) {
+      console.error(error);
+    }
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setState({ ...state, username: e.target.value });
-  };
+    setIsLoading(false);
+  }, [state]);
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const trimmedUsername = state.username.trim();
+    const trimmedUsername = usernameInputValue.trim();
     const isEmptyString = trimmedUsername === "";
     if (isEmptyString) {
       return;
     }
 
+    setIsEndPage(false);
+    setUsernameInputValue(trimmedUsername);
+    setState({ ...INITIAL_FILTERING, username: trimmedUsername });
     router.push(`/meoguri?name=${trimmedUsername}`);
   };
 
   useEffect(() => {
-    if (router.query.name === undefined) {
+    if (!router.isReady || router.query.name === undefined) {
       return;
     }
 
-    setState((prevState) => ({
-      ...prevState,
-      username: router.query.name as string,
-    }));
-    getProfiles(router.query.name as string);
-  }, [router.query.name, getProfiles]);
+    const queryName = router.query.name as string;
+    setUsernameInputValue(queryName);
+    setState({ ...INITIAL_FILTERING, username: queryName });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady]);
+
+  useEffect(() => {
+    getProfiles();
+  }, [getProfiles]);
 
   return (
     <>
@@ -113,20 +142,13 @@ const Meoguri = () => {
           <Layout>
             <Title>머구리 찾기</Title>
 
-            <Test>router {router.query.name}</Test>
-            <Test>상태 {JSON.stringify(state, null, " ")}</Test>
-            <Test>{`API queryString: ${Object.entries(state)
-              .map((entry) => entry.join("="))
-              .join("&")}
-            `}</Test>
-
             <Form onSubmit={handleSubmit}>
               <Input
                 searchIcon
                 name="name"
                 width="400px"
-                value={state.username}
-                onChange={handleChange}
+                value={usernameInputValue}
+                onChange={(e) => setUsernameInputValue(e.target.value)}
               />
               <Button
                 colorType="main-color"
@@ -138,23 +160,30 @@ const Meoguri = () => {
               </Button>
             </Form>
 
-            {isLoading ? "로딩 중..." : null}
-            <MeoguriCardContainer isLoading={isLoading}>
+            <MeoguriCardContainer>
               {!isLoading &&
               router.query.name !== undefined &&
               profiles.length === 0
                 ? "검색 결과가 없습니다."
-                : profiles.map(({ profileId, imageUrl, isFollow, username }) =>
-                    profileId === DUMMY_USER_INFO.profileId ? null : (
-                      <Following
-                        profileImg={imageUrl}
-                        userName={username}
-                        following={isFollow}
-                        key={profileId}
-                      />
+                : profiles.map(
+                    ({ profileId, imageUrl, isFollow, username }, index) => (
+                      <div
+                        ref={
+                          isLastCard(index, profiles.length) ? setTarget : null
+                        }
+                      >
+                        <Following
+                          profileId={profileId}
+                          profileImg={imageUrl}
+                          userName={username}
+                          following={isFollow}
+                          key={profileId}
+                        />
+                      </div>
                     )
                   )}
             </MeoguriCardContainer>
+            {isLoading ? "로딩 중..." : null}
           </Layout>
         </PageLayout.Article>
       </PageLayout>
@@ -174,12 +203,6 @@ const Form = styled.form`
   margin-bottom: 37px;
 `;
 
-const MeoguriCardContainer = styled(FollowCardContainer)<{
-  isLoading: boolean;
-}>`
-  display: ${(props) => (props.isLoading ? "none" : "flex")};
-`;
-
-const Test = styled.div``;
+const MeoguriCardContainer = styled(FollowCardContainer)``;
 
 export default Meoguri;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
-  머구리찾기 페이지 검색 결과 목록 무한 스크롤로 구현
# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- useIntersectionObserver 훅을 사용하여 구현
  - Follow 컴포넌트 목록 중 가장 마지막 컴포넌트가 항상 옵저버의 관찰 대상이 되도록 설정
  - threshold 0.8
- URL로 (올바르게..) 접근 시 검색되도록 동기화
  - ex. "/meoguri?name=효니"

## 데모
- 무한 스크롤 데모

https://user-images.githubusercontent.com/96400112/183650457-548dc6e7-38eb-498b-86b4-3a44734c4d3f.mp4

- URL 동기화 데모
![url 동기화](https://user-images.githubusercontent.com/96400112/183650517-a2f98045-1ae5-4720-9e76-5fc07ea5abe6.gif)


<!-- closes #이슈번호 -->
closes #168 