### PR TITLE
Feature/#170 contextAction

### DIFF
--- a/components/common/bookmarkCard/bookmarkCard.tsx
+++ b/components/common/bookmarkCard/bookmarkCard.tsx
@@ -64,7 +64,12 @@ const BookmarkCard = ({ data, deleteBookmark }: BookmarkProps) => {
         </div>
         <div>
           <Star id={id.toString()} favorite={isFavorite} />
-          <DropBox deleteBookmark={deleteBookmark} isWriter={isWriter} id={id}>
+          <DropBox
+            tags={tags}
+            deleteBookmark={deleteBookmark}
+            isWriter={isWriter}
+            id={id}
+          >
             <More />
           </DropBox>
         </div>

--- a/components/common/bookmarkCard/dropBox.tsx
+++ b/components/common/bookmarkCard/dropBox.tsx
@@ -1,3 +1,4 @@
+import { useProfileDispatch } from "@/hooks/useProfile";
 import useToggle from "@/hooks/useToggle";
 import { color, text } from "@/styles/theme";
 import bookmarkAPI from "@/utils/apis/bookmark";
@@ -8,6 +9,7 @@ export interface DropBoxProps {
   children: JSX.Element;
   isWriter: boolean;
   id: number;
+  tags?: string[];
   deleteBookmark: (id: number) => void;
 }
 
@@ -15,10 +17,12 @@ const DropBox = ({
   children,
   isWriter = true,
   id,
+  tags,
   deleteBookmark,
 }: DropBoxProps) => {
   const [checked, toggle] = useToggle(false);
   const router = useRouter();
+  const dispatch = useProfileDispatch();
 
   const share = (e: React.MouseEvent<HTMLElement>) => {
     alert("공유하기");
@@ -39,6 +43,10 @@ const DropBox = ({
     if (isDelete) {
       try {
         await bookmarkAPI.deleteBookmark(id);
+        dispatch({
+          type: "REMOVE_BOOKMARK",
+          tags,
+        });
         alert("북마크가 제거되었습니다.");
         callback(id);
       } catch (error) {

--- a/components/detail/index.tsx
+++ b/components/detail/index.tsx
@@ -55,6 +55,10 @@ const DetailPage = ({ data, id }: { data: BookmarkDetail; id: number }) => {
     if (deleteConfirm) {
       try {
         await bookmarkAPI.deleteBookmark(id);
+        dispatch({
+          type: "REMOVE_BOOKMARK",
+          tags,
+        });
         router.back();
       } catch (error) {
         console.error(error);

--- a/components/detail/index.tsx
+++ b/components/detail/index.tsx
@@ -2,11 +2,11 @@ import { color, text } from "@/styles/theme";
 import styled from "@emotion/styled";
 import Image from "next/image";
 import React, { useEffect, useState } from "react";
-import { BookmarkDetail, ProfileDetail } from "@/types/model";
+import { BookmarkDetail } from "@/types/model";
 import { useRouter } from "next/router";
 import bookmarkAPI from "@/utils/apis/bookmark";
 import followAPI from "@/utils/apis/follow";
-import profileAPI from "@/utils/apis/profile";
+import { useProfileDispatch, useProfileState } from "@/hooks/useProfile";
 import BackButton from "../common/backButton";
 import Star from "../common/star";
 import Button from "../common/button";
@@ -28,32 +28,21 @@ const DetailPage = ({ data, id }: { data: BookmarkDetail; id: number }) => {
     reactionCount,
   } = data;
   const [isFollow, setIsFollow] = useState(profile.isFollow);
+  const { username } = useProfileState();
+  const dispatch = useProfileDispatch();
 
   useEffect(() => {
     setIsFollow(profile.isFollow);
   }, [profile.isFollow]);
 
-  const [loginUser, setLoginUser] = useState<ProfileDetail>();
-
-  // 임시 로그인 중인 유저
-  // 이후 contextAPI로 변경
-  useEffect(() => {
-    (async () => {
-      try {
-        const loginUserData = await profileAPI.getMyProfile();
-        setLoginUser(loginUserData.data);
-      } catch (e) {
-        console.error(e);
-      }
-    })();
-  }, []);
-
   const followRequest = async () => {
     try {
       if (isFollow) {
         await followAPI.deleteFollow(profile.profileId);
+        dispatch({ type: "UN_FOLLOW" });
       } else {
         await followAPI.createFollow(profile.profileId);
+        dispatch({ type: "FOLLOW" });
       }
       setIsFollow(!isFollow);
     } catch (error) {
@@ -77,7 +66,7 @@ const DetailPage = ({ data, id }: { data: BookmarkDetail; id: number }) => {
     <Page>
       <FlexBetween>
         <BackButton />
-        {loginUser?.username === profile.username ? (
+        {username === profile.username ? (
           <FlexBetween style={{ width: "190px" }}>
             <Button
               onClick={() => router.push(`/edit/${id}`)}

--- a/components/myEdit/selectCategoryModal.tsx
+++ b/components/myEdit/selectCategoryModal.tsx
@@ -13,22 +13,25 @@ const SelectCategoryModal = ({
   setCategories,
   categories,
 }: {
-  categories: string[];
-  setCategories: (categories: string[]) => void;
+  categories: typeof CATEGORY[number][];
+  setCategories: (categories: typeof CATEGORY[number][]) => void;
 }) => {
   const [isShowModal, setIsShowModal] = useState<boolean>(false);
   const [favoriteCategories, setFavoriteCategories] =
-    useState<string[]>(categories);
+    useState<typeof CATEGORY[number][]>(categories);
 
   const handleCategoryClick: ChangeInputHandler = (e) => {
-    if (favoriteCategories.includes(e.target.name)) {
+    if (favoriteCategories.includes(e.target.name as typeof CATEGORY[number])) {
       const filtered = favoriteCategories.filter(
         (category) => category !== e.target.name
       );
       setFavoriteCategories(filtered);
       return;
     }
-    setFavoriteCategories([...favoriteCategories, e.target.name]);
+    setFavoriteCategories([
+      ...favoriteCategories,
+      e.target.name as typeof CATEGORY[number],
+    ]);
   };
 
   const submitCategories = () => {

--- a/store/ProfileProvider.tsx
+++ b/store/ProfileProvider.tsx
@@ -27,7 +27,9 @@ type Action =
         imageUrl: string;
         favoriteCategories: typeof CATEGORY[number][];
       };
-    };
+    }
+  | { type: "FOLLOW" }
+  | { type: "UN_FOLLOW" };
 
 export const ProfileContext = createContext<ProfileDetail | null>(null);
 export const ProfileDispatchContext =
@@ -49,6 +51,23 @@ const ProfileReducer = (state: ProfileDetail, action: Action) => {
         favoriteCategories,
       };
     }
+    case "FOLLOW":
+      return {
+        ...state,
+        followerCount: state.followeeCount + 1,
+      };
+    case "UN_FOLLOW": {
+      if (state.followeeCount < 1) {
+        return {
+          ...state,
+        };
+      }
+      return {
+        ...state,
+        followerCount: state.followeeCount - 1,
+      };
+    }
+
     default:
       throw new Error(`Unhanded action type`);
   }

--- a/store/ProfileProvider.tsx
+++ b/store/ProfileProvider.tsx
@@ -1,4 +1,3 @@
-import { getProfile } from "@/types/dummyData";
 import { ProfileDetail } from "@/types/model";
 import profileAPI from "@/utils/apis/profile";
 import {
@@ -9,7 +8,13 @@ import {
   useEffect,
 } from "react";
 
-const initialUser = getProfile; // 더미data
+const initialUser = {
+  profileId: 1,
+  favoriteCategories: [""],
+  username: "",
+  followerCount: 0,
+  followeeCount: 0,
+};
 type SampleDispatch = Dispatch<Action>;
 type Action = { type: "GET_PROFILES"; profile: ProfileDetail };
 

--- a/store/ProfileProvider.tsx
+++ b/store/ProfileProvider.tsx
@@ -1,4 +1,5 @@
 import { ProfileDetail } from "@/types/model";
+import { CATEGORY } from "@/types/type";
 import profileAPI from "@/utils/apis/profile";
 import {
   createContext,
@@ -8,15 +9,25 @@ import {
   useEffect,
 } from "react";
 
-const initialUser = {
+const initialUser: ProfileDetail = {
   profileId: 1,
-  favoriteCategories: [""],
+  favoriteCategories: [],
   username: "",
   followerCount: 0,
   followeeCount: 0,
 };
 type SampleDispatch = Dispatch<Action>;
-type Action = { type: "GET_PROFILES"; profile: ProfileDetail };
+type Action =
+  | { type: "GET_PROFILES"; profile: ProfileDetail }
+  | {
+      type: "EDIT_PROFILES";
+      profile: {
+        bio: string;
+        username: string;
+        imageUrl: string;
+        favoriteCategories: typeof CATEGORY[number][];
+      };
+    };
 
 export const ProfileContext = createContext<ProfileDetail | null>(null);
 export const ProfileDispatchContext =
@@ -28,6 +39,16 @@ const ProfileReducer = (state: ProfileDetail, action: Action) => {
   switch (action.type) {
     case "GET_PROFILES":
       return { ...action.profile };
+    case "EDIT_PROFILES": {
+      const { bio, username, imageUrl, favoriteCategories } = action.profile;
+      return {
+        ...state,
+        bio,
+        username,
+        imageUrl,
+        favoriteCategories,
+      };
+    }
     default:
       throw new Error(`Unhanded action type`);
   }

--- a/store/ProfileProvider.tsx
+++ b/store/ProfileProvider.tsx
@@ -39,7 +39,6 @@ type Action =
   | {
       type: "REMOVE_BOOKMARK";
       tags?: string[];
-      categories?: typeof CATEGORY[number];
     };
 
 export const ProfileContext = createContext<ProfileDetail | null>(null);
@@ -117,9 +116,30 @@ const ProfileReducer = (state: ProfileDetail, action: Action) => {
       };
     }
     case "REMOVE_BOOKMARK": {
-      const { tags, categories } = state;
+      const { tags } = action;
+      let setTags: TagType[] = [];
+
+      if (tags) {
+        tags?.forEach((removeTag) => {
+          state.tags?.forEach((tag, i) => {
+            if (tag.tag === removeTag) {
+              if (tag.count <= 1) {
+                setTags.splice(i, 1);
+              } else {
+                setTags = [
+                  ...setTags,
+                  { tag: removeTag, count: tag.count - 1 },
+                ];
+              }
+            } else {
+              setTags = [...setTags, { tag: tag.tag, count: tag.count }];
+            }
+          });
+        });
+      }
       return {
         ...state,
+        tags: setTags,
       };
     }
     default:

--- a/types/model.ts
+++ b/types/model.ts
@@ -14,8 +14,8 @@ export interface ProfileList {
 export interface ProfileDetail {
   profileId: number;
   imageUrl?: string;
-  favoriteCategories: string[];
-  categories?: string[];
+  favoriteCategories: typeof CATEGORY[number][];
+  categories?: typeof CATEGORY[number][];
   username: string;
   bio?: string;
   followerCount: number;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->

# 작업사항
- [x] 회원정보 수정
  - [x] 회원정보 수정시 bio, imageUrl, username, 선호카테고리의 전역상태가 변경됨니다.
  - [x] 회원정보 수정 페이지에 해당 contextAPI action연결
- [x] 팔로우/팔로우취소
  - [x] 팔로우, 취소 action을 각각 실행하면 followee 의 카운트가 올라가거나 내려감니다. 
          0아래로는 내려가지않습니다. 
- [x] bookmark 추가/삭제
  - [x] 북마크 추가시 추가되는 북마크의 categories와 tags를 받습니다. 
  해당 categories가 처음 추가될 경우 categories가 추가됨니다. 
  기존에 있던 tag는 count만 +1 됨니다.
  기존에 없던 tag는 추가되고 count 1 인 상태가 됨니다.
  - [x] 북마크 삭제시 삭제되는 북마크의 tags를 받습니다.
  해당 tag가 0개이면 목록에서 제거 함니다.
  해당 tag가 2개 이상이면 count만 -1 해줌니다.

아래는 bookmark 추가/삭제에 대한 동작입니다. 
이런식으로 동작합니다.
![녹화_2022_08_10_01_26_45_13](https://user-images.githubusercontent.com/87519250/183708140-5823d75c-4b6e-45df-8cde-1aa6d97b3246.gif)


# 관련 이슈
ex ) 카테고리 "IT"에 북마크 1개가 남아있을경우, 이를 제거하면 카테고리배열에 "IT"가 제거 되어야 합니다.  
하지만 해당 카테고리에 몇개의 북마크가 있는지 알 수 있는 방법이 없어서 카테고리 제거는 하지 못했습니다. 



closes #170
