### PR TITLE
[#178] feat: 다른 사람 페이지 팔로우+/팔로우 취소 낙관적 업데이트

### DIFF
--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -18,7 +18,8 @@ import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import { Profile, ProfileDetail } from "@/types/model";
 import profileAPI from "@/utils/apis/profile";
 import { getQueryString } from "@/utils/queryString";
-import useIntersectionObserver from "../../../hooks/useIntersectionObserver";
+import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+import { useProfileDispatch, useProfileState } from "@/hooks/useProfile";
 
 const PAGE_SIZE = 8;
 
@@ -39,6 +40,9 @@ const INITIAL_FILTERING: Filtering = {
 const Follow = () => {
   const router = useRouter();
 
+  const myProfile = useProfileState();
+  const myProfileDispatcher = useProfileDispatch();
+
   const [userProfile, setUserProfile] = useState<ProfileDetail>();
   const [state, setState] = useState(INITIAL_FILTERING);
   const [followProfiles, setFollowProfiles] = useState<{
@@ -52,6 +56,72 @@ const Follow = () => {
     setState({ ...state, [name]: id, page: INITIAL_FILTERING.page });
     setIsEndPage(false);
   };
+  const handleUserInfo = () => {
+    if (!userProfile) {
+      return;
+    }
+
+    const isDeleteFollowAction = userProfile.isFollow;
+
+    const nextFollowerCount = isDeleteFollowAction
+      ? userProfile.followerCount - 1
+      : userProfile.followerCount + 1;
+    setUserProfile({
+      ...userProfile,
+      followerCount: nextFollowerCount,
+      isFollow: !userProfile.isFollow,
+    });
+
+    const nextFolloweeCount = isDeleteFollowAction
+      ? myProfile.followeeCount - 1
+      : myProfile.followeeCount + 1;
+    myProfileDispatcher({
+      type: "GET_PROFILES",
+      profile: { ...myProfile, followeeCount: nextFolloweeCount },
+    });
+
+    if (state.tab === "follower") {
+      const { profileId, imageUrl, username, isFollow } = myProfile;
+
+      const nextFollowProfilesValue = isDeleteFollowAction
+        ? followProfiles.value.filter(
+            (profile) => profile.profileId !== profileId
+          )
+        : [
+            ...followProfiles.value,
+            { profileId, imageUrl, username, isFollow } as Profile,
+          ];
+      setFollowProfiles({ ...followProfiles, value: nextFollowProfilesValue });
+    }
+  };
+  const handleFollowing = (profileId: number) => {
+    if (!userProfile) {
+      return;
+    }
+
+    const index = followProfiles.value.findIndex(
+      (followProfile) => followProfile.profileId === profileId
+    );
+    const isDeleteFollowAction = followProfiles.value[index].isFollow;
+
+    const nextFolloweeCount = isDeleteFollowAction
+      ? myProfile.followeeCount - 1
+      : myProfile.followeeCount + 1;
+    myProfileDispatcher({
+      type: "GET_PROFILES",
+      profile: {
+        ...myProfile,
+        followeeCount: nextFolloweeCount,
+      },
+    });
+
+    const copiedValue = [...followProfiles.value];
+    copiedValue[index].isFollow = !copiedValue[index].isFollow;
+    setFollowProfiles({
+      ...followProfiles,
+      value: copiedValue,
+    });
+  };
 
   const getUserProfile = useCallback(async () => {
     const profileId = parseInt(router.query.profileId as string, 10);
@@ -64,11 +134,10 @@ const Follow = () => {
     }
   }, [router.query.profileId]);
   const getFollowProfiles = useCallback(async () => {
-    if (!userProfile) {
+    if (!userProfile?.profileId) {
       return;
     }
 
-    const { profileId } = userProfile;
     const { tab, ...query } = state;
     const queryString = getQueryString(query);
 
@@ -77,7 +146,7 @@ const Follow = () => {
 
       const {
         data: { profiles },
-      } = await profileAPI.getFollow(profileId, tab, queryString);
+      } = await profileAPI.getFollow(userProfile.profileId, tab, queryString);
 
       if (profiles.length === 0 || profiles.length < query.size) {
         setIsEndPage(true);
@@ -97,7 +166,7 @@ const Follow = () => {
     } catch (error) {
       console.error(error);
     }
-  }, [state, userProfile]);
+  }, [state, userProfile?.profileId]);
 
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isEndPage) {
@@ -140,9 +209,12 @@ const Follow = () => {
         <PageLayout.Aside>
           {userProfile ? (
             <>
-              <UserInfo data={userProfile} />
+              <UserInfo data={userProfile} handleClick={handleUserInfo} />
               <MyFilterMenu
-                tagList={userProfile.tags}
+                tagList={userProfile.tags?.map(({ tag, count }) => ({
+                  name: tag,
+                  count,
+                }))}
                 categoryList={userProfile.categories}
                 getCategoryData={() => {}}
                 getTagsData={() => {}}
@@ -183,13 +255,14 @@ const Follow = () => {
                         ? setTarget
                         : null
                     }
+                    key={profileId}
                   >
                     <Following
                       profileId={profileId}
                       profileImg={imageUrl}
                       userName={username}
                       following={isFollow}
-                      key={profileId}
+                      handleClick={handleFollowing}
                     />
                   </div>
                 )


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 다른사람페이지에서 UserInfo & Following 컴포넌트에 props로 전달할 handleClick 콜백 함수 로직 구현
- `팔로우하기`, `팔로우 취소하기` API 요청에 따른 유저 context 낙관적 업데이트

# 작업사항
- UserInfo 컴포넌트에서
  - `팔로우 +`
    - 유저 context의 followeeCount + 1
    - UserInfo의 followerCount + 1
    - UserInfo의 `팔로우 +` 버튼을 `팔로우 취소` 버튼으로 토글
    - 팔로워 목록을 보고 있다면, 팔로워 목록에 사용자의 정보로 만들어진 Following 컴포넌트 추가
  - `팔로우 취소`
    - 유저 context의 followeeCount - 1
    - UserInfo의 followerCount - 1
    - UserInfo의 `팔로우 취소` 버튼을 `팔로우 +` 버튼으로 토글
    - 팔로워 목록을 보고 있다면, 팔로워 목록에 사용자의 정보로 만들어진 Following 컴포넌트 제거
- Following 컴포넌트에서
  - `팔로우 +`
    - 유저 context의 followeeCount + 1
    - Following 컴포넌트의 `팔로우 +` 버튼을 `팔로우 취소` 버튼으로 토글
  - `팔로우 취소`
    - 유저 context의 followeeCount - 1
    - Following 컴포넌트의 `팔로우 취소` 버튼을 `팔로우 +` 버튼으로 토글
## 데모
브라우저 개발자 도구에서 유저 context의 followeeCount 값 동기화가 잘 되고 있는 것을 확인할 수 있습니다!

https://user-images.githubusercontent.com/96400112/183814991-a3645c90-55bc-4b14-96a0-9f7b9bd997b9.mp4

<!-- closes #이슈번호 -->
closes #178 