### PR TITLE
Fix/#191-following

### DIFF
--- a/components/common/following.tsx
+++ b/components/common/following.tsx
@@ -6,6 +6,7 @@ import { useCallback, useState } from "react";
 import FollowAPI from "@/utils/apis/follow";
 
 export interface FollowingProps {
+  isMine?: boolean;
   profileId: number;
   profileImg?: string;
   userName: string;
@@ -14,6 +15,7 @@ export interface FollowingProps {
 }
 
 const Following = ({
+  isMine,
   profileId,
   profileImg,
   userName,
@@ -56,7 +58,7 @@ const Following = ({
         src={profileImg || "/image/default-profile-image.png"}
       />
       <UserName>{userName}</UserName>
-      {following ? (
+      {isMine && following ? (
         <FollowingBtn
           colorType="skyblue"
           width="128"

--- a/components/common/following.tsx
+++ b/components/common/following.tsx
@@ -58,29 +58,31 @@ const Following = ({
         src={profileImg || "/image/default-profile-image.png"}
       />
       <UserName>{userName}</UserName>
-      {isMine && following ? (
-        <FollowingBtn
-          colorType="skyblue"
-          width="128"
-          height="42"
-          buttonType={following ? "line" : "small"}
-          onClick={handleUnfollow}
-          {...props}
-        >
-          팔로우 취소
-        </FollowingBtn>
-      ) : (
-        <FollowingBtn
-          colorType="skyblue"
-          width="128"
-          height="42"
-          buttonType={following ? "line" : "small"}
-          onClick={handleFollow}
-          {...props}
-        >
-          팔로우 +
-        </FollowingBtn>
-      )}
+      {following
+        ? !isMine && (
+            <FollowingBtn
+              colorType="skyblue"
+              width="128"
+              height="42"
+              buttonType={following ? "line" : "small"}
+              onClick={handleUnfollow}
+              {...props}
+            >
+              팔로우 취소
+            </FollowingBtn>
+          )
+        : !isMine && (
+            <FollowingBtn
+              colorType="skyblue"
+              width="128"
+              height="42"
+              buttonType={following ? "line" : "small"}
+              onClick={handleFollow}
+              {...props}
+            >
+              팔로우 +
+            </FollowingBtn>
+          )}
     </Card>
   );
 };


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요
검색 결과로 나오는 자신의 카드에 팔로우/언팔로우 버튼이 보이지 않도록 isMine props를 추가했습니다.
<!-- 간략 설명 -->

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
**_isMine=true_**
<img width="604" alt="image" src="https://user-images.githubusercontent.com/67778677/183831153-e7ef504e-1a8b-4418-a517-e5e0a1153552.png">

**_isMine=false_**
<img width="604" alt="image" src="https://user-images.githubusercontent.com/67778677/183831204-022985c8-3b7c-4760-9c14-6d0f38319ec4.png">

<!-- closes #이슈번호 -->
closes #191 