### PR TITLE
Feature/#210-머구리페이지 라우팅, Top버튼, 자신의 팔로잉 카드, 검색 결과 없음

### DIFF
--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -15,6 +15,7 @@ import { Profile } from "@/types/model";
 import { getQueryString } from "@/utils/queryString";
 import { useProfileDispatch, useProfileState } from "@/hooks/useProfile";
 import NoResult from "@/components/common/noResult";
+import Top from "@/components/common/top";
 import useIntersectionObserver from "../hooks/useIntersectionObserver";
 import { FollowCardContainer, isLastCard, Layout } from "./my/follow";
 
@@ -211,6 +212,7 @@ const Meoguri = () => {
                 )
               )}
             </MeoguriCardContainer>
+            <Top />
           </Layout>
         </PageLayout.Article>
       </PageLayout>

--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -14,13 +14,9 @@ import profileAPI from "@/utils/apis/profile";
 import { Profile } from "@/types/model";
 import { getQueryString } from "@/utils/queryString";
 import { useProfileDispatch, useProfileState } from "@/hooks/useProfile";
+import NoResult from "@/components/common/noResult";
 import useIntersectionObserver from "../hooks/useIntersectionObserver";
-import {
-  DUMMY_USER_INFO,
-  FollowCardContainer,
-  isLastCard,
-  Layout,
-} from "./my/follow";
+import { FollowCardContainer, isLastCard, Layout } from "./my/follow";
 
 // TODO: 본인 제외하기, 무한 스크롤, 유저 컨텍스트 연결
 
@@ -157,10 +153,7 @@ const Meoguri = () => {
         <PageLayout.Aside>
           <UserInfo data={userProfile} />
           <MyFilterMenu
-            tagList={userProfile.tags?.map(({ tag, count }) => ({
-              name: tag,
-              count,
-            }))}
+            tagList={userProfile.tags}
             categoryList={userProfile.categories}
             getCategoryData={() => {}}
             getTagsData={() => {}}
@@ -191,28 +184,29 @@ const Meoguri = () => {
             <MeoguriCardContainer>
               {!isLoading &&
               router.query.name !== undefined &&
-              profiles.length === 0
-                ? "검색 결과가 없습니다."
-                : profiles.map(
-                    ({ profileId, imageUrl, isFollow, username }, index) => (
-                      <div
-                        ref={
-                          isLastCard(index, profiles.length) ? setTarget : null
-                        }
-                      >
-                        <Following
-                          profileId={profileId}
-                          profileImg={imageUrl}
-                          userName={username}
-                          following={isFollow}
-                          key={profileId}
-                          handleClick={handleFollow}
-                        />
-                      </div>
-                    )
-                  )}
+              profiles.length === 0 ? (
+                <NoResult />
+              ) : (
+                profiles.map(
+                  ({ profileId, imageUrl, isFollow, username }, index) => (
+                    <div
+                      ref={
+                        isLastCard(index, profiles.length) ? setTarget : null
+                      }
+                    >
+                      <Following
+                        profileId={profileId}
+                        profileImg={imageUrl}
+                        userName={username}
+                        following={isFollow}
+                        key={profileId}
+                        handleClick={handleFollow}
+                      />
+                    </div>
+                  )
+                )
+              )}
             </MeoguriCardContainer>
-            {isLoading ? "로딩 중..." : null}
           </Layout>
         </PageLayout.Article>
       </PageLayout>

--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -19,7 +19,7 @@ import Top from "@/components/common/top";
 import useIntersectionObserver from "../hooks/useIntersectionObserver";
 import { FollowCardContainer, isLastCard, Layout } from "./my/follow";
 
-// TODO: 본인 제외하기, 무한 스크롤, 유저 컨텍스트 연결
+// TODO: 유저 컨텍스트 연결
 
 const PAGE_SIZE = 8;
 
@@ -206,6 +206,7 @@ const Meoguri = () => {
                         following={isFollow}
                         key={profileId}
                         handleClick={handleFollow}
+                        isMine={profileId === userProfile.profileId}
                       />
                     </div>
                   )

--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -155,8 +155,12 @@ const Meoguri = () => {
           <MyFilterMenu
             tagList={userProfile.tags}
             categoryList={userProfile.categories}
-            getCategoryData={() => {}}
-            getTagsData={() => {}}
+            getCategoryData={(category) => {
+              router.push(`/my/category?category=${category}`);
+            }}
+            getTagsData={(tags) => {
+              router.push(`/my/tag?tags=${tags[0]}`);
+            }}
           />
         </PageLayout.Aside>
         <PageLayout.Article>


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 머구리페이지 라우팅, Top 버튼, 자신의 팔로잉 카드 구분

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 사이드바 필터메뉴 라우팅
  - 카테고리 선택 시 "/my/category?category=선택된카테고리"로 이동
  - 태그 선택 시 "/my/tag?tags=선택된태그"로 이동
- Top 버튼 추가
- Following 컴포넌트에 props.isMine 값을 전달하여 자신의 팔로잉 카드인 경우 "팔로우 + / 팔로우 취소" 버튼이 안 보이도록 처리
- 검색 결과 없습니다 UI 추가
![머구리페이지](https://user-images.githubusercontent.com/96400112/183977506-2e24ef31-2986-4b7b-8183-d23cf620c026.gif)

<!-- closes #이슈번호 -->
closes #210 