### PR TITLE
Feature/#219-다른사람페이지 팔로잉 라우팅

### DIFF
--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -181,12 +181,18 @@ const Follow = () => {
   });
 
   useEffect(() => {
-    if (router.query.profileId === undefined) {
+    if (!router.isReady || myProfile.profileId === 0) {
       return;
     }
 
+    const queryProfileId = parseInt(router.query.profileId as string, 10);
+    if (queryProfileId === myProfile.profileId) {
+      router.push(`/my/follow`);
+    }
+
     getUserProfile();
-  }, [router.query.profileId, getUserProfile]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady, myProfile.profileId]);
 
   useEffect(() => {
     getFollowProfiles();

--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -1,9 +1,7 @@
 import PageLayout from "@/components/common/pageLayout";
-import styled from "@emotion/styled";
 import Head from "next/head";
 import UserInfo from "@/components/common/userInfo";
 import MyFilterMenu from "@/components/common/filterMenu/myFilterMenu";
-import { getProfile } from "@/types/dummyData";
 import FollowRadio from "@/components/follow/followRadio";
 import Following from "@/components/common/following";
 import { useRouter } from "next/router";
@@ -210,13 +208,18 @@ const Follow = () => {
             <>
               <UserInfo data={userProfile} handleClick={handleUserInfo} />
               <MyFilterMenu
-                tagList={userProfile.tags?.map(({ tag, count }) => ({
-                  name: tag,
-                  count,
-                }))}
+                tagList={userProfile.tags}
                 categoryList={userProfile.categories}
-                getCategoryData={() => {}}
-                getTagsData={() => {}}
+                getCategoryData={(category) => {
+                  router.push(
+                    `/profile/${userProfile.profileId}/category?category=${category}`
+                  );
+                }}
+                getTagsData={(tags) => {
+                  router.push(
+                    `/profile/${userProfile.profileId}/tag?tags=${tags[0]}`
+                  );
+                }}
               />
             </>
           ) : (

--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -1,7 +1,6 @@
 import PageLayout from "@/components/common/pageLayout";
 import Head from "next/head";
 import UserInfo from "@/components/common/userInfo";
-import MyFilterMenu from "@/components/common/filterMenu/myFilterMenu";
 import FollowRadio from "@/components/follow/followRadio";
 import Following from "@/components/common/following";
 import { useRouter } from "next/router";
@@ -17,6 +16,7 @@ import profileAPI from "@/utils/apis/profile";
 import { getQueryString } from "@/utils/queryString";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
 import { useProfileDispatch, useProfileState } from "@/hooks/useProfile";
+import OtherFilterMenu from "@/components/common/filterMenu/otherFilterMenu";
 
 const PAGE_SIZE = 8;
 
@@ -213,7 +213,7 @@ const Follow = () => {
           {userProfile ? (
             <>
               <UserInfo data={userProfile} handleClick={handleUserInfo} />
-              <MyFilterMenu
+              <OtherFilterMenu
                 tagList={userProfile.tags}
                 categoryList={userProfile.categories}
                 getCategoryData={(category) => {


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 다른사람페이지 팔로잉 라우팅
# 작업사항
- 사이드바 MyFilterMenu -> OtherFilterMenu 컴포넌트로 변경
- OtherFilterMenu 컴포넌트 클릭 시 라우팅
  - 카테고리 선택 시 "/profile/프로필아이디/category?category=선택된카테고리"로 이동
  - 태그 선택 시 "/profile/프로필아이디/tag?tags=선택된태그"로 이동
- "/profile/자신의 프로필 아이디/follow" 접근 시 "/my/follow"로 이동 
<!-- 상세 설명 관련이미지 첨부 -->
![otherPage routing](https://user-images.githubusercontent.com/96400112/184096500-8abe4591-be42-4fbc-ac2a-8e94f3f5881a.gif)



<!-- closes #이슈번호 -->
