### PR TITLE
Fix/#238-피드페이지 

### DIFF
--- a/components/common/filterMenu/feedFilterMenu.tsx
+++ b/components/common/filterMenu/feedFilterMenu.tsx
@@ -1,14 +1,18 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import FilterBorder from "./filterBorder";
 import FilterHeader from "./filterHeader";
 import FilterElement from "./filterElement";
 
 interface FeedFilterMenuProps {
+  category?: string;
   getCategoryData: (arr: string) => void;
 }
 
-const FeedFilterMenu = ({ getCategoryData }: FeedFilterMenuProps) => {
-  const [selectedCategory, setSelectedCategory] = useState<string>("");
+const FeedFilterMenu = ({
+  category = "",
+  getCategoryData,
+}: FeedFilterMenuProps) => {
+  const [selectedCategory, setSelectedCategory] = useState<string>(category);
   const categoryList = [
     "전체",
     "자기계발",
@@ -28,6 +32,10 @@ const FeedFilterMenu = ({ getCategoryData }: FeedFilterMenuProps) => {
     setSelectedCategory(element);
     getCategoryData(element);
   };
+
+  useEffect(() => {
+    setSelectedCategory(category);
+  }, [category]);
 
   return (
     <FilterBorder>

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -17,7 +17,7 @@ import Label from "@/components/common/label";
 import Checkbox from "@/components/common/checkbox";
 import Select from "@/components/common/select";
 import Pagination from "@/components/common/pagination";
-import { Bookmark, BookmarkList } from "@/types/model";
+import { BookmarkList } from "@/types/model";
 import BookmarkCard from "@/components/common/bookmarkCard";
 import { CATEGORY } from "@/types/type";
 import bookmarkAPI from "@/utils/apis/bookmark";
@@ -57,6 +57,7 @@ const Feed = () => {
     bookmarks: [],
   });
   const [searchTitleInputValue, setSearchTitleInputValue] = useState("");
+  const [routerIsReady, setRouterIsReady] = useState(false);
 
   const searchTitleRef = useRef<HTMLInputElement>(null);
 
@@ -169,12 +170,18 @@ const Feed = () => {
       setState({ ...INITIAL_FILTERING, ...query });
     }
     setSearchTitleInputValue(searchTitle);
+    setRouterIsReady(true);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady]);
 
   useEffect(() => {
+    if (!routerIsReady) {
+      return;
+    }
+
     getFeedBookmarks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getFeedBookmarks]);
 
   return (
@@ -185,7 +192,12 @@ const Feed = () => {
 
       <PageLayout>
         <PageLayout.Aside>
-          <FeedFilterMenu getCategoryData={handleChangeCategory} />
+          {routerIsReady ? (
+            <FeedFilterMenu
+              getCategoryData={handleChangeCategory}
+              category={state.category}
+            />
+          ) : null}
         </PageLayout.Aside>
 
         <PageLayout.Article>
@@ -237,7 +249,7 @@ const Feed = () => {
                   >
                     <Select.Trigger>정렬</Select.Trigger>
                     <Select.OptionList>
-                      <Select.Option value="update">최신 순</Select.Option>
+                      <Select.Option value="upload">최신 순</Select.Option>
                       <Select.Option value="like">좋아요 순</Select.Option>
                     </Select.OptionList>
                   </Select>

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -27,7 +27,7 @@ import * as theme from "@/styles/theme";
 const PAGE_SIZE = 8;
 
 type CategoryType = "전체" | typeof CATEGORY[number];
-type OrderType = "update" | "like";
+type OrderType = "upload" | "like";
 
 type Filtering = {
   category: CategoryType;
@@ -42,7 +42,7 @@ const INITIAL_FILTERING: Filtering = {
   category: "전체",
   searchTitle: "",
   follow: false,
-  order: "update",
+  order: "upload",
   page: 1,
   size: PAGE_SIZE,
 };
@@ -60,12 +60,16 @@ const Feed = () => {
   const searchTitleRef = useRef<HTMLInputElement>(null);
 
   const getFeedBookmarks = useCallback(async () => {
-    const { searchTitle, ...query } = state;
-    const queryString =
-      searchTitle !== "" ? getQueryString(state) : getQueryString(query);
+    setSearchTitleInputValue(state.searchTitle);
 
-    setSearchTitleInputValue(searchTitle);
-
+    const query: Partial<Filtering> = { ...state };
+    if (query.category === "전체") {
+      delete query.category;
+    }
+    if (query.searchTitle === "") {
+      delete query.searchTitle;
+    }
+    const queryString = getQueryString(query);
     const response = await bookmarkAPI.getFeedBookmarks(queryString);
     setFeedBookmarks(response.data);
   }, [state]);
@@ -227,7 +231,7 @@ const Feed = () => {
                     onChange={handleChangeOrder}
                     selectedOption={{
                       value: state.order,
-                      text: state.order === "update" ? "최신 순" : "좋아요 순",
+                      text: state.order === "upload" ? "최신 순" : "좋아요 순",
                     }}
                   >
                     <Select.Trigger>정렬</Select.Trigger>

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -23,6 +23,7 @@ import { CATEGORY } from "@/types/type";
 import bookmarkAPI from "@/utils/apis/bookmark";
 import { getQueryString } from "@/utils/queryString";
 import * as theme from "@/styles/theme";
+import NoResult from "@/components/common/noResult";
 
 const PAGE_SIZE = 8;
 
@@ -245,13 +246,17 @@ const Feed = () => {
             </Form>
 
             <BookmarkContainer>
-              {feedBookmarks.bookmarks.map((bookmark) => (
-                <BookmarkCard
-                  key={bookmark.id}
-                  data={bookmark}
-                  deleteBookmark={() => {}}
-                />
-              ))}
+              {state.searchTitle !== "" && feedBookmarks.totalCount === 0 ? (
+                <NoResult />
+              ) : (
+                feedBookmarks.bookmarks.map((bookmark) => (
+                  <BookmarkCard
+                    key={bookmark.id}
+                    data={bookmark}
+                    deleteBookmark={() => {}}
+                  />
+                ))
+              )}
             </BookmarkContainer>
 
             <div style={{ display: "flex", justifyContent: "center" }}>

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -306,7 +306,6 @@ const Follow = styled.div`
 `;
 
 const BookmarkContainer = styled.div`
-  height: 549px;
   margin-bottom: 90px;
 `;
 


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

피드페이지 수정

# 작업사항
- 피드 북마크 목록 조회 API
  - category=전체가 아닌 category값 없이 요청하도록 변경
  - order=update가 아닌 order=upload로 변경
- 카드 목록의 height값 조절
- 검색 결과 없음 추가
- 피드필터메뉴 초기값(=기본 선택값) 받도록 수정

<!-- 상세 설명 관련이미지 첨부 -->

https://user-images.githubusercontent.com/96400112/184178034-edfb01b4-5b7c-43ae-9d50-3a2301e5e965.mp4




<!-- closes #이슈번호 -->
closes #238