### PR TITLE
Refactor/#211-팔로우하기/취소하기 유저 context action type 변경

### DIFF
--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -19,8 +19,6 @@ import Top from "@/components/common/top";
 import useIntersectionObserver from "../hooks/useIntersectionObserver";
 import { FollowCardContainer, isLastCard, Layout } from "./my/follow";
 
-// TODO: 유저 컨텍스트 연결
-
 const PAGE_SIZE = 8;
 
 type Filtering = {
@@ -113,16 +111,11 @@ const Meoguri = () => {
     );
     const isDeleteFollowAction = profiles[index].isFollow;
 
-    const nextFolloweeCount = isDeleteFollowAction
-      ? userProfile.followeeCount - 1
-      : userProfile.followeeCount + 1;
-    userProfileDispatcher({
-      type: "GET_PROFILES",
-      profile: {
-        ...userProfile,
-        followeeCount: nextFolloweeCount,
-      },
-    });
+    if (isDeleteFollowAction) {
+      userProfileDispatcher({ type: "UN_FOLLOW" });
+    } else {
+      userProfileDispatcher({ type: "FOLLOW" });
+    }
 
     const copiedValue = [...profiles];
     copiedValue[index].isFollow = !copiedValue[index].isFollow;
@@ -152,7 +145,7 @@ const Meoguri = () => {
 
       <PageLayout>
         <PageLayout.Aside>
-          <UserInfo data={userProfile} />
+          <UserInfo />
           <MyFilterMenu
             tagList={userProfile.tags}
             categoryList={userProfile.categories}
@@ -198,13 +191,13 @@ const Meoguri = () => {
                       ref={
                         isLastCard(index, profiles.length) ? setTarget : null
                       }
+                      key={profileId}
                     >
                       <Following
                         profileId={profileId}
                         profileImg={imageUrl}
                         userName={username}
                         following={isFollow}
-                        key={profileId}
                         handleClick={handleFollow}
                         isMine={profileId === userProfile.profileId}
                       />

--- a/pages/my/follow.tsx
+++ b/pages/my/follow.tsx
@@ -49,19 +49,13 @@ const Follow = () => {
       (followProfile) => followProfile.profileId === profileId
     );
     const isDeleteFollowAction = followProfiles.value[index].isFollow;
+    if (isDeleteFollowAction) {
+      userProfileDispatcher({ type: "UN_FOLLOW" });
+    } else {
+      userProfileDispatcher({ type: "FOLLOW" });
+    }
+
     const isFolloweeTab = state.tab === "followee";
-
-    const nextFolloweeCount = isDeleteFollowAction
-      ? userProfile.followeeCount - 1
-      : userProfile.followeeCount + 1;
-    userProfileDispatcher({
-      type: "GET_PROFILES",
-      profile: {
-        ...userProfile,
-        followeeCount: nextFolloweeCount,
-      },
-    });
-
     const copiedValue = [...followProfiles.value];
     if (isFolloweeTab) {
       copiedValue.splice(index, 1);
@@ -137,7 +131,7 @@ const Follow = () => {
 
       <PageLayout>
         <PageLayout.Aside>
-          <UserInfo data={userProfile} />
+          <UserInfo />
           <MyFilterMenu
             tagList={userProfile.tags}
             categoryList={userProfile.categories}

--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -99,18 +99,13 @@ const Follow = () => {
     const index = followProfiles.value.findIndex(
       (followProfile) => followProfile.profileId === profileId
     );
-    const isDeleteFollowAction = followProfiles.value[index].isFollow;
 
-    const nextFolloweeCount = isDeleteFollowAction
-      ? myProfile.followeeCount - 1
-      : myProfile.followeeCount + 1;
-    myProfileDispatcher({
-      type: "GET_PROFILES",
-      profile: {
-        ...myProfile,
-        followeeCount: nextFolloweeCount,
-      },
-    });
+    const isDeleteFollowAction = followProfiles.value[index].isFollow;
+    if (isDeleteFollowAction) {
+      myProfileDispatcher({ type: "UN_FOLLOW" });
+    } else {
+      myProfileDispatcher({ type: "FOLLOW" });
+    }
 
     const copiedValue = [...followProfiles.value];
     copiedValue[index].isFollow = !copiedValue[index].isFollow;
@@ -271,6 +266,7 @@ const Follow = () => {
                       userName={username}
                       following={isFollow}
                       handleClick={handleFollowing}
+                      isMine={profileId === myProfile.profileId}
                     />
                   </div>
                 )


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 머구리찾기, 내 팔로잉, 남 팔로잉 페이지 리팩토링
# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 팔로우하기/취소하기에 대한 유저 context 업데이트 action type 변경
- 남 팔로잉 페이지 오류 수정
  - Following 컴포넌트에 `props.isMine`을 전달하지 않아서, 자신의 Following인 경우에도 팔로우+/취소 버튼이 뜨던 문제

<!-- closes #이슈번호 -->
closes #211 