### PR TITLE
fix/#260-myEditPage

### DIFF
--- a/components/myEdit/editPage.tsx
+++ b/components/myEdit/editPage.tsx
@@ -89,12 +89,13 @@ const EditPage = () => {
         editData.append("image", file);
       }
       await profileAPI.editProfile(editData);
+
       dispatch({
         type: "EDIT_PROFILES",
         profile: {
           bio: input.bio,
           username: input.userName,
-          imageUrl: URL.createObjectURL(file as File),
+          imageUrl: typeof file === "string" ? file : URL.createObjectURL(file),
           favoriteCategories: categories,
         },
       });


### PR DESCRIPTION
# 개요
myEditPage 오류 수정
<!-- 간략 설명 -->

# 작업사항
- 정보수정시 api요청이 성공했는데 프론트에서 유저네임 중복 오류가 뜬다.
- file에서 오류가 생겨서 그 이후로 오류로 판정되어 catch에서 잡힌것 같습니다.



closes #260
