### PR TITLE
Feature/#177-피드페이지 북마크 삭제 처리

### DIFF
--- a/components/common/bookmarkCard/bookmarkCard.tsx
+++ b/components/common/bookmarkCard/bookmarkCard.tsx
@@ -1,5 +1,5 @@
 import { color, text } from "@/styles/theme";
-import { Bookmark } from "@/types/model";
+import { Bookmark, Profile } from "@/types/model";
 import dateFormat from "@/utils/dateFormat";
 import styled from "@emotion/styled";
 import { useRouter } from "next/router";
@@ -11,6 +11,7 @@ import DropBox from "./dropBox";
 export interface BookmarkProps {
   data: Bookmark;
   deleteBookmark: (id: number) => void;
+  isMine?: boolean;
 }
 
 const OPEN_TYPE = {
@@ -21,7 +22,7 @@ const OPEN_TYPE = {
 
 const feedUrlRegExp = /^feed.*/g;
 
-const BookmarkCard = ({ data, deleteBookmark }: BookmarkProps) => {
+const BookmarkCard = ({ data, deleteBookmark, isMine }: BookmarkProps) => {
   const {
     category,
     url,
@@ -103,7 +104,7 @@ const BookmarkCard = ({ data, deleteBookmark }: BookmarkProps) => {
             <DropBox
               setIsShowShareBookmark={setIsShowShareBookmark}
               deleteBookmark={deleteBookmark}
-              isWriter={isWriter}
+              isWriter={isMine ?? isWriter}
               id={id}
             >
               <More />

--- a/components/common/pagination.tsx
+++ b/components/common/pagination.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import * as theme from "@/styles/theme";
 import Image from "next/image";
 
@@ -13,6 +13,11 @@ export interface PaginationProps {
 
 const Pagination = ({ defaultPage, count, onChange }: PaginationProps) => {
   const [currentPage, setCurrentPage] = useState(defaultPage ?? 1);
+
+  useEffect(() => {
+    setCurrentPage(defaultPage || 1);
+  }, [defaultPage]);
+
   const startPage = (() => {
     if (count < MAX_LENGTH) {
       return 1;

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -1,4 +1,6 @@
 import Head from "next/head";
+import styled from "@emotion/styled";
+import { useRouter } from "next/router";
 import {
   ChangeEvent,
   FormEvent,
@@ -7,23 +9,23 @@ import {
   useCallback,
   useRef,
 } from "react";
-import { useRouter } from "next/router";
+import {
+  Input,
+  PageLayout,
+  Button,
+  Label,
+  Checkbox,
+  Select,
+  Pagination,
+  BookmarkCard,
+  NoResult,
+} from "@/components/common";
 import FeedFilterMenu from "@/components/common/filterMenu/feedFilterMenu";
-import Input from "@/components/common/input";
-import PageLayout from "@/components/common/pageLayout";
-import styled from "@emotion/styled";
-import Button from "@/components/common/button";
-import Label from "@/components/common/label";
-import Checkbox from "@/components/common/checkbox";
-import Select from "@/components/common/select";
-import Pagination from "@/components/common/pagination";
 import { BookmarkList } from "@/types/model";
-import BookmarkCard from "@/components/common/bookmarkCard";
 import { CATEGORY } from "@/types/type";
 import bookmarkAPI from "@/utils/apis/bookmark";
 import { getQueryString } from "@/utils/queryString";
 import * as theme from "@/styles/theme";
-import NoResult from "@/components/common/noResult";
 
 const PAGE_SIZE = 8;
 

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -275,7 +275,7 @@ const Feed = () => {
             <div style={{ display: "flex", justifyContent: "center" }}>
               <Pagination
                 defaultPage={state.page}
-                count={Math.ceil(feedBookmarks.bookmarks.length / state.size)}
+                count={Math.ceil(feedBookmarks.totalCount / state.size)}
                 onChange={handleChangePages}
               />
             </div>

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -26,6 +26,7 @@ import { CATEGORY } from "@/types/type";
 import bookmarkAPI from "@/utils/apis/bookmark";
 import { getQueryString } from "@/utils/queryString";
 import * as theme from "@/styles/theme";
+import { useProfileState } from "@/hooks/useProfile";
 
 const PAGE_SIZE = 8;
 
@@ -53,6 +54,7 @@ const INITIAL_FILTERING: Filtering = {
 const Feed = () => {
   const router = useRouter();
 
+  const { profileId } = useProfileState();
   const [state, setState] = useState<Filtering>(INITIAL_FILTERING);
   const [feedBookmarks, setFeedBookmarks] = useState<BookmarkList>({
     totalCount: 0,
@@ -143,6 +145,25 @@ const Feed = () => {
       page: INITIAL_FILTERING.page,
       searchTitle: trimmedSearchTitle,
     });
+  };
+
+  const handleBookmarkDelete = (id: number) => {
+    const { totalCount, bookmarks } = feedBookmarks;
+    const nextBookmarks = bookmarks.filter((bookmark) => bookmark.id !== id);
+    const nextBookmarksLength = nextBookmarks.length;
+
+    if (nextBookmarksLength !== 0) {
+      setFeedBookmarks({
+        totalCount,
+        bookmarks: nextBookmarks,
+      });
+    } else {
+      const needPrevPage =
+        state.page === Math.ceil(feedBookmarks.totalCount / state.size) &&
+        state.page !== 1;
+      const nextPage = needPrevPage ? state.page - 1 : state.page;
+      setState({ ...state, page: nextPage });
+    }
   };
 
   useEffect(() => {
@@ -266,7 +287,8 @@ const Feed = () => {
                   <BookmarkCard
                     key={bookmark.id}
                     data={bookmark}
-                    deleteBookmark={() => {}}
+                    deleteBookmark={handleBookmarkDelete}
+                    isMine={profileId === bookmark.profile?.profileId}
                   />
                 ))
               )}
@@ -325,6 +347,7 @@ const Follow = styled.div`
 
 const BookmarkContainer = styled.div`
   margin-bottom: 90px;
+  min-height: 288px;
 `;
 
 export default Feed;

--- a/types/model.ts
+++ b/types/model.ts
@@ -62,7 +62,7 @@ export interface BookmarkDetail {
 
 export interface BookmarkList {
   totalCount: number;
-  bookmarks: Bookmark[];
+  bookmarks: (Bookmark & { profile?: Profile })[];
 }
 
 export interface Notification {


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 피드페이지 북마크 삭제 처리
# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->

- 삭제 로직 (글씨 죄송합니다..)
  <img width="567" alt="image" src="https://user-images.githubusercontent.com/96400112/184325803-09c127a0-ac05-4ce9-ac91-f248ed547d05.png">

## 데모

https://user-images.githubusercontent.com/96400112/184328298-09e347b1-5c25-4aa5-9e65-1387b5314457.mp4



https://user-images.githubusercontent.com/96400112/184328320-c58217d1-a7d6-4d98-87fc-6d0a07128a1c.mov


# 관련 이슈

<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->
- `피드 북마크 목록 조회` API에 모든 북마크의 isWrite 값이 false로 반환되는 오류가 있어 임시로 작성자의 아이디와 현재 사용자의 아이디를 비교해서 삭제할 수 있도록 처리했습니다.
  - model.ts
  - bookMarkCard.tsx


<!-- closes #이슈번호 -->
closes #177 