### PR TITLE
Fix/#269-피드, 머구리찾기 페이지 네비게이션 클릭 시 검색창 초기화가 안 되는 문제

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -203,6 +203,13 @@ const Feed = () => {
   }, [router.isReady]);
 
   useEffect(() => {
+    if (Object.keys(router.query).length === 0) {
+      setSearchTitleInputValue("");
+      setState(INITIAL_FILTERING);
+    }
+  }, [router.query]);
+
+  useEffect(() => {
     getFeedBookmarks();
   }, [getFeedBookmarks]);
 

--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -135,6 +135,14 @@ const Meoguri = () => {
   }, [router.isReady]);
 
   useEffect(() => {
+    if (Object.keys(router.query).length === 0) {
+      setUsernameInputValue("");
+      setState(INITIAL_FILTERING);
+      setProfiles([]);
+    }
+  }, [router.query]);
+
+  useEffect(() => {
     getProfiles();
   }, [getProfiles]);
 


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 피드 페이지, 머구리 찾기 페이지인 상태에서 헤더 네비게이션의 해당 페이지로 크릭 시 상태와 검색창이 초기화되지 않는 문제

# 작업사항
![초기화](https://user-images.githubusercontent.com/96400112/184429807-10015d32-04b0-42d4-8354-b92998f5804e.gif)


<!-- closes #이슈번호 -->
closes #269 