### PR TITLE
Refactor/#286-프로필 목록 조회 API, `hasNext` 응답값 추가로 무한스크롤 로직 변경

### DIFF
--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -70,13 +70,11 @@ const Meoguri = () => {
     const queryString = getQueryString(state);
 
     try {
-      const response = await profileAPI.getProfilesByUsername(queryString);
-      const responseProfiles = response.data.profiles;
+      const {
+        data: { profiles: responseProfiles, hasNext },
+      } = await profileAPI.getProfilesByUsername(queryString);
 
-      if (
-        responseProfiles.length === 0 ||
-        responseProfiles.length < state.size
-      ) {
+      if (!hasNext) {
         setIsEndPage(true);
       }
 

--- a/pages/my/follow.tsx
+++ b/pages/my/follow.tsx
@@ -75,18 +75,18 @@ const Follow = () => {
       setFollowProfiles(({ value }) => ({ value, isLoading: true }));
 
       const {
-        data: { profiles },
+        data: { profiles: responseProfiles, hasNext },
       } = await profileAPI.getFollow(userProfile.profileId, tab, queryString);
 
-      if (profiles.length === 0 || profiles.length < query.size) {
+      if (!hasNext) {
         setIsEndPage(true);
       }
 
       setFollowProfiles(({ value }) => {
         const nextValue =
           query.page === INITIAL_FILTERING.page
-            ? profiles
-            : [...value, ...profiles];
+            ? responseProfiles
+            : [...value, ...responseProfiles];
 
         return {
           value: nextValue,

--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -133,18 +133,18 @@ const Follow = () => {
       setFollowProfiles(({ value }) => ({ value, isLoading: true }));
 
       const {
-        data: { profiles },
+        data: { profiles: responseProfiles, hasNext },
       } = await profileAPI.getFollow(userProfile.profileId, tab, queryString);
 
-      if (profiles.length === 0 || profiles.length < query.size) {
+      if (!hasNext) {
         setIsEndPage(true);
       }
 
       setFollowProfiles(({ value }) => {
         const nextValue =
           query.page === INITIAL_FILTERING.page
-            ? profiles
-            : [...value, ...profiles];
+            ? responseProfiles
+            : [...value, ...responseProfiles];
 
         return {
           value: nextValue,

--- a/types/model.ts
+++ b/types/model.ts
@@ -9,6 +9,7 @@ export interface Profile {
 
 export interface ProfileList {
   profiles: Profile[];
+  hasNext: boolean;
 }
 
 export interface ProfileDetail {


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

![image](https://user-images.githubusercontent.com/96400112/184465503-d6dbe231-3aea-41e9-b2e7-da7075eb6eb1.png)

# 작업사항

- `ProfileList` 타입에 `hasNext` 불리언 타입 추가 (`@/types/model.ts`)
- 무한스크롤 마지막 페이지임을 판별하는 조건문 변경 (프로필 목록 응답값의 길이로 판별 → `hasNext` 값으로 판별)
  - 머구리찾기 페이지
  - 마이 팔로잉 페이지
  - 남의 팔로잉 페이지

<!-- closes #이슈번호 -->
closes #286 