### PR TITLE
Feature/#288-회원가입 완료 시 유저 context 연결, 취소 시 세션 초기화

### DIFF
--- a/components/common/logoutTooltip.tsx
+++ b/components/common/logoutTooltip.tsx
@@ -1,20 +1,8 @@
 import styled from "@emotion/styled";
 import { color, text } from "@/styles/theme";
-import storage from "@/utils/localStorage";
-import { signOut } from "next-auth/react";
-import { useRouter } from "next/router";
+import { handleLogout } from "@/utils/logout";
 
 const LogoutTooltip = ({ ...props }) => {
-  const handleLogout = () => {
-    try {
-      storage.removeItem("OAUTH_TYPE");
-      storage.removeItem("LINKOCEAN_TOKEN");
-      signOut({ callbackUrl: "/" });
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   return (
     <Tooltip {...props}>
       <Arrow />

--- a/components/main/index.ts
+++ b/components/main/index.ts
@@ -1,4 +1,3 @@
 export { default as GoogleLoginButton } from "./googleLoginButton";
 export { default as KakaoLoginButton } from "./kakaoLoginButton";
 export { default as NaverLoginButton } from "./naverLoginButton";
-export { default as LoginButton } from "./loginButton";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,21 +1,18 @@
 import Head from "next/head";
-import { signIn, signOut, useSession } from "next-auth/react";
+import { signIn, useSession } from "next-auth/react";
 import Image from "next/image";
 import styled from "@emotion/styled";
 import * as theme from "@/styles/theme";
 import { useEffect, MouseEvent, useCallback } from "react";
 import { useRouter } from "next/router";
-import profileAPI, { LoginPayload, OauthType } from "@/utils/apis/profile";
-import storage from "@/utils/localStorage";
 import {
   GoogleLoginButton,
   NaverLoginButton,
   KakaoLoginButton,
-  LoginButton,
 } from "@/components/main";
-
-export const OAUTH_TYPE = "OAUTH_TYPE";
-export const TOKEN_KEY = "LINKOCEAN_TOKEN";
+import profileAPI, { LoginPayload, OauthType } from "@/utils/apis/profile";
+import storage from "@/utils/localStorage";
+import { STORAGE_KEY } from "@/utils/constants";
 
 export default function Home() {
   const { data: session } = useSession();
@@ -25,7 +22,7 @@ export default function Home() {
   const handleLogin = (e: MouseEvent<HTMLButtonElement>) => {
     const oauthType = e.currentTarget.name as OauthType;
     const upperOAuthType = oauthType.toUpperCase();
-    storage.setItem(OAUTH_TYPE, upperOAuthType);
+    storage.setItem(STORAGE_KEY.oauthType, upperOAuthType);
 
     (async () => {
       try {
@@ -35,17 +32,11 @@ export default function Home() {
       }
     })();
   };
-  const handleSignOut = () => {
-    signOut();
-
-    storage.removeItem(OAUTH_TYPE);
-    storage.removeItem(TOKEN_KEY);
-  };
 
   const login = useCallback(async (payload: LoginPayload) => {
     try {
       const response = await profileAPI.login(payload);
-      storage.setItem(TOKEN_KEY, response.data.token);
+      storage.setItem(STORAGE_KEY.token, response.data.token);
     } catch (error) {
       console.error(error);
     }
@@ -61,18 +52,22 @@ export default function Home() {
   }, [router]);
 
   useEffect(() => {
-    if (session) {
-      (async () => {
-        const oauthType = storage.getItem(OAUTH_TYPE, "");
-        if (oauthType === "") {
-          return;
-        }
-
-        await login({ email: session?.user?.email as string, oauthType });
-        await loginSuccess();
-      })();
+    if (!session) {
+      return;
     }
-  }, [login, loginSuccess, session, session?.user?.email]);
+
+    (async () => {
+      const oauthType = storage.getItem(STORAGE_KEY.oauthType, "");
+      if (oauthType === "") {
+        return;
+      }
+
+      await login({ email: session?.user?.email as string, oauthType });
+      await loginSuccess();
+    })();
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session]);
 
   return (
     <>
@@ -119,13 +114,6 @@ export default function Home() {
                 onClick={handleLogin}
                 disabled={!!session}
               />
-              <LogoutButton
-                type="button"
-                onClick={handleSignOut}
-                disabled={!session}
-              >
-                임시 로그아웃
-              </LogoutButton>
             </ButtonContainer>
           </LoginContainer>
 
@@ -177,7 +165,7 @@ const LoginContainer = styled.div`
   height: 530px;
   border: 3px solid ${theme.color.$skyBlue};
   border-radius: 8px;
-  padding: 53px 63px 62px;
+  padding: 68px 62px;
   text-align: center;
   box-sizing: border-box;
 `;
@@ -185,7 +173,7 @@ const LoginContainer = styled.div`
 const Logo = styled.h1`
   display: flex;
   flex-direction: column;
-  margin-bottom: 33px;
+  margin-bottom: 42px;
 `;
 
 const LinkOcean = styled.div`
@@ -196,11 +184,6 @@ const ButtonContainer = styled.div`
   display: inline-flex;
   flex-direction: column;
   gap: 8px;
-`;
-
-const LogoutButton = styled(LoginButton)`
-  color: #fff;
-  background-color: ${theme.color.$mainColor};
 `;
 
 const AboutContainer = styled.div`

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,8 +14,8 @@ import {
   LoginButton,
 } from "@/components/main";
 
-const OAUTH_TYPE = "OAUTH_TYPE";
-const TOKEN_KEY = "LINKOCEAN_TOKEN";
+export const OAUTH_TYPE = "OAUTH_TYPE";
+export const TOKEN_KEY = "LINKOCEAN_TOKEN";
 
 export default function Home() {
   const { data: session } = useSession();

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -89,6 +89,13 @@ const SignUp = () => {
 
     signup({ username: username.value, categories: userCategory.value });
   };
+  const handleCancel = (e?: MouseEvent<HTMLAnchorElement>) => {
+    e?.preventDefault();
+    storage.removeItem(OAUTH_TYPE);
+    storage.removeItem(TOKEN_KEY);
+
+    signOut({ callbackUrl: "/" });
+  };
 
   const signup = async (payload: ProfilesPayload) => {
     try {
@@ -122,6 +129,12 @@ const SignUp = () => {
       }
     }
   };
+
+  useEffect(() => {
+    router.events.on("beforeHistoryChange", handleCancel);
+    return () => router.events.off("beforeHistoryChange", handleCancel);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <>
@@ -180,7 +193,9 @@ const SignUp = () => {
           </StyledButton>
 
           <Link href="/" passHref>
-            <LinkText>이미 다른 계정이 있나요? 로그인하러 가기</LinkText>
+            <LinkText onClick={handleCancel}>
+              이미 다른 계정이 있나요? 로그인하러 가기
+            </LinkText>
           </Link>
         </Form>
       </Layout>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,7 +1,6 @@
 import {
   ChangeEventHandler,
   FormEvent,
-  MouseEvent,
   useCallback,
   useEffect,
   useRef,
@@ -11,7 +10,6 @@ import axios from "axios";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { signOut } from "next-auth/react";
 import {
   Button,
   CategoryItem,
@@ -20,14 +18,14 @@ import {
   Label,
 } from "@/components/common";
 import { useProfileDispatch } from "@/hooks/useProfile";
-import storage from "@/utils/localStorage";
 import { CATEGORY } from "@/types/type";
 import { ProfileDetail } from "@/types/model";
 import { usernameRegExp } from "@/utils/validation";
 import profileAPI, { ProfilesPayload } from "@/utils/apis/profile";
 import * as theme from "@/styles/theme";
 import styled from "@emotion/styled";
-import { TOKEN_KEY, OAUTH_TYPE } from "./index";
+import { handleLogout } from "@/utils/logout";
+import { LINKOCEAN_PATH } from "@/utils/constants";
 
 const INITIAL_PROFILE = {
   favoriteCategories: ["인문", "사회", "정치"],
@@ -89,13 +87,6 @@ const SignUp = () => {
 
     signup({ username: username.value, categories: userCategory.value });
   };
-  const handleCancel = (e?: MouseEvent<HTMLAnchorElement>) => {
-    e?.preventDefault();
-    storage.removeItem(OAUTH_TYPE);
-    storage.removeItem(TOKEN_KEY);
-
-    signOut({ callbackUrl: "/" });
-  };
 
   const signup = async (payload: ProfilesPayload) => {
     try {
@@ -113,7 +104,7 @@ const SignUp = () => {
         } as ProfileDetail,
       });
 
-      router.push("/my/favorite");
+      router.push(LINKOCEAN_PATH.myCategory);
     } catch (error) {
       if (axios.isAxiosError(error) && error.response !== undefined) {
         const isDuplicatedUserName = error.response.status === 400;
@@ -129,12 +120,6 @@ const SignUp = () => {
       }
     }
   };
-
-  useEffect(() => {
-    router.events.on("beforeHistoryChange", handleCancel);
-    return () => router.events.off("beforeHistoryChange", handleCancel);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <>
@@ -193,7 +178,7 @@ const SignUp = () => {
           </StyledButton>
 
           <Link href="/" passHref>
-            <LinkText onClick={handleCancel}>
+            <LinkText onClick={handleLogout}>
               이미 다른 계정이 있나요? 로그인하러 가기
             </LinkText>
           </Link>

--- a/utils/apis/profile.ts
+++ b/utils/apis/profile.ts
@@ -16,7 +16,7 @@ const profileAPI = {
     authInstance.get<{ hasProfile: boolean }>("/login/success"),
   logout: () => authInstance.post("/users/logout"),
   createProfile: (payload: ProfilesPayload) =>
-    authInstance.post("/profiles", payload),
+    authInstance.post<{ id: number }>("/profiles", payload),
   getOtherProfile: (profileId: number) =>
     authInstance.get<ProfileDetail>(`/profiles/${profileId}`),
   getFollow: (profileId: number, tab: string, queryString: string) =>

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,23 @@
+/* eslint-disable import/prefer-default-export */
+export const STORAGE_KEY = {
+  oauthType: "OAUTH_TYPE",
+  token: "LINKOCEAN_TOKEN",
+};
+
+export const LINKOCEAN_PATH = {
+  login: "/",
+  signup: "/signup",
+  myFavorite: "/my/favorite",
+  myTag: "/my/tag",
+  myCategory: "my/category",
+  myFollow: "/my/follow",
+  myEdit: "/my/edit",
+  myDetail: "/my/detail",
+  meoguri: "/meoguri",
+  other: "/profile",
+  create: "/create",
+  notification: "/notification",
+  feed: "/feed",
+  feedDetail: "/feed/detail",
+  notFound: "/404",
+};

--- a/utils/logout.ts
+++ b/utils/logout.ts
@@ -1,0 +1,16 @@
+import { signOut } from "next-auth/react";
+import { MouseEvent } from "react";
+import storage from "./localStorage";
+import { LINKOCEAN_PATH, STORAGE_KEY } from "./constants";
+
+// eslint-disable-next-line import/prefer-default-export
+export const handleLogout = <T>(e?: MouseEvent<T>) => {
+  if (e?.preventDefault) {
+    e.preventDefault();
+  }
+
+  storage.removeItem(STORAGE_KEY.oauthType);
+  storage.removeItem(STORAGE_KEY.token);
+
+  signOut({ callbackUrl: LINKOCEAN_PATH.login });
+};


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 회원가입 완료 시 유저 context 연결
- 회원가입 취소 시 세션 초기화 후 로그인 페이지로 이동

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 회원가입 완료 시 유저 context에 초기 유저 데이터 업데이트
- 회원가입 취소 시 (= 회원가입 완료 버튼 밑 "이미 다른 계정이 있나요? 로그인하러 가기" 문구 클릭) 세션, 로컬 스토리지 초기화 후 로그인 페이지로 이동
- 로그인 페이지 `임시 로그아웃` 버튼 삭제
- 로그아웃 유틸 함수로 추출
  - `LogoutToolTip` 컴포넌트 수정 → 마음에 안 든다면 변경 전으로 돌리겠습니당
- 상수화
  - 로컬 스토리지 키
  - 링크오션 상대 경로
```javascript
 export const STORAGE_KEY = {
    oauthType: "OAUTH_TYPE",
    token: "LINKOCEAN_TOKEN",
  };

  export const LINKOCEAN_PATH = {
    login: "/",
    signup: "/signup",
    myFavorite: "/my/favorite",
    myTag: "/my/tag",
    myCategory: "my/category",
    myFollow: "/my/follow",
    myEdit: "/my/edit",
    myDetail: "/my/detail",
    meoguri: "/meoguri",
    other: "/profile",
    create: "/create",
    notification: "/notification",
    feed: "/feed",
    feedDetail: "/feed/detail",
    notFound: "/404",
  };
```

## 데모
> 회원가입 후 새로고침을 하지 않아도 유저 정보가 보입니다! 
회원가입 도중 취소하는 데모를 촬영해야 했는데..잊고 안 했습니다. 그런데 제가 모든 계정으로 회원가입을 다 해서 촬영을 할 수 없는 상황입니다😥 

https://user-images.githubusercontent.com/96400112/184475621-0afeceb0-e19d-4489-af7f-7ae34aa9abd2.mp4


# 관련 이슈
- 회원가입 페이지에서 브라우저의 뒤로가기 버튼을 클릭 시, 이벤트를 가로채 세션/로컬 스토리지 초기화를 하려 했으나 실패
- 상대 경로 상수화에서 제가 사용하려고 로그인, 회원가입만 만들려다가 우선 다른 것들도 상수화해 봤습니다. 상태 경로 중 "/profile/{profileId}/*" 경로들은 상수보다는 함수로 만드는 것이 더 좋아 보여 포함하지 않았습니다.
  - 사용할 것 같다면 이대로 merge하고, 안 사용할 것 같다면 폐기해버리겠습니당

<!-- closes #이슈번호 -->
closes #288 