### PR TITLE
Refactor/#297-머구리찾기, 피드, 팔로잉 페이지 상대 경로 문자열 -> 상수

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -1,5 +1,4 @@
 import Head from "next/head";
-import styled from "@emotion/styled";
 import { useRouter } from "next/router";
 import {
   ChangeEvent,
@@ -9,6 +8,7 @@ import {
   useCallback,
   useRef,
 } from "react";
+import styled from "@emotion/styled";
 import {
   Input,
   PageLayout,
@@ -23,9 +23,10 @@ import {
 import FeedFilterMenu from "@/components/common/filterMenu/feedFilterMenu";
 import { BookmarkList } from "@/types/model";
 import { CATEGORY } from "@/types/type";
+import { useProfileState } from "@/hooks/useProfile";
 import bookmarkAPI from "@/utils/apis/bookmark";
 import { getQueryString } from "@/utils/queryString";
-import { useProfileState } from "@/hooks/useProfile";
+import { LINKOCEAN_PATH } from "@/utils/constants";
 import * as theme from "@/styles/theme";
 
 const PAGE_SIZE = 8;
@@ -90,7 +91,7 @@ const Feed = () => {
         searchTitle === ""
           ? `category=${category}`
           : getQueryString({ category, searchTitle });
-      router.push(`/feed?${queryString}`);
+      router.push(`${LINKOCEAN_PATH.feed}?${queryString}`);
     },
     [router]
   );
@@ -184,7 +185,7 @@ const Feed = () => {
       ["전체", ...CATEGORY].includes(query.category as string);
 
     if (!isValidQuery) {
-      router.push("/404");
+      router.push(LINKOCEAN_PATH.notFound);
     }
 
     const searchTitle = query.searchTitle as string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/main";
 import profileAPI, { LoginPayload, OauthType } from "@/utils/apis/profile";
 import storage from "@/utils/localStorage";
-import { STORAGE_KEY } from "@/utils/constants";
+import { LINKOCEAN_PATH, STORAGE_KEY } from "@/utils/constants";
 
 export default function Home() {
   const { data: session } = useSession();
@@ -44,7 +44,9 @@ export default function Home() {
   const loginSuccess = useCallback(async () => {
     try {
       const response = await profileAPI.loginSuccess();
-      const nextPage = response.data.hasProfile ? "/my/favorite" : "/signup";
+      const nextPage = response.data.hasProfile
+        ? LINKOCEAN_PATH.myFavorite
+        : LINKOCEAN_PATH.signup;
       router.push(nextPage);
     } catch (error) {
       console.error(error);

--- a/pages/meoguri.tsx
+++ b/pages/meoguri.tsx
@@ -1,7 +1,6 @@
-import styled from "@emotion/styled";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import * as theme from "@/styles/theme";
+import styled from "@emotion/styled";
 import { FormEvent, useState, useEffect, useCallback } from "react";
 import MyFilterMenu from "@/components/common/filterMenu/myFilterMenu";
 import {
@@ -13,11 +12,13 @@ import {
   NoResult,
   Top,
 } from "@/components/common";
-import profileAPI from "@/utils/apis/profile";
 import { Profile } from "@/types/model";
-import { getQueryString } from "@/utils/queryString";
+import profileAPI from "@/utils/apis/profile";
 import { useProfileDispatch, useProfileState } from "@/hooks/useProfile";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+import { getQueryString } from "@/utils/queryString";
+import * as theme from "@/styles/theme";
+import { LINKOCEAN_PATH } from "@/utils/constants";
 import { FollowCardContainer, isLastCard, Layout } from "./my/follow";
 
 const PAGE_SIZE = 8;
@@ -102,7 +103,7 @@ const Meoguri = () => {
     setIsEndPage(false);
     setUsernameInputValue(trimmedUsername);
     setState({ ...INITIAL_FILTERING, username: trimmedUsername });
-    router.push(`/meoguri?name=${trimmedUsername}`);
+    router.push(`${LINKOCEAN_PATH.meoguri}?name=${trimmedUsername}`);
   };
   const handleFollow = (profileId: number) => {
     const index = profiles.findIndex(
@@ -110,11 +111,9 @@ const Meoguri = () => {
     );
     const isDeleteFollowAction = profiles[index].isFollow;
 
-    if (isDeleteFollowAction) {
-      userProfileDispatcher({ type: "UN_FOLLOW" });
-    } else {
-      userProfileDispatcher({ type: "FOLLOW" });
-    }
+    userProfileDispatcher({
+      type: isDeleteFollowAction ? "UN_FOLLOW" : "FOLLOW",
+    });
 
     const copiedValue = [...profiles];
     copiedValue[index].isFollow = !copiedValue[index].isFollow;
@@ -157,10 +156,10 @@ const Meoguri = () => {
             tagList={userProfile.tags}
             categoryList={userProfile.categories}
             getCategoryData={(category) => {
-              router.push(`/my/category?category=${category}`);
+              router.push(`${LINKOCEAN_PATH.myCategory}?category=${category}`);
             }}
             getTagsData={(tags) => {
-              router.push(`/my/tag?tags=${tags[0]}`);
+              router.push(`${LINKOCEAN_PATH.myTag}?tags=${tags[0]}`);
             }}
           />
         </PageLayout.Aside>
@@ -224,7 +223,7 @@ const Meoguri = () => {
 const Title = styled.h2`
   margin: 10px 0 29px 4px;
   color: ${theme.color.$gray800};
-  ${theme.text.$headline5};
+  ${theme.text.$headline5}
 `;
 
 const Form = styled.form`

--- a/pages/my/follow.tsx
+++ b/pages/my/follow.tsx
@@ -8,8 +8,9 @@ import { Following, UserInfo, PageLayout } from "@/components/common";
 import { Profile } from "@/types/model";
 import profileAPI from "@/utils/apis/profile";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
-import { getQueryString } from "@/utils/queryString";
 import { useProfileState, useProfileDispatch } from "@/hooks/useProfile";
+import { getQueryString } from "@/utils/queryString";
+import { LINKOCEAN_PATH } from "@/utils/constants";
 
 const PAGE_SIZE = 8;
 export const isLastCard = (index: number, length: number) =>
@@ -47,11 +48,9 @@ const Follow = () => {
       (followProfile) => followProfile.profileId === profileId
     );
     const isDeleteFollowAction = followProfiles.value[index].isFollow;
-    if (isDeleteFollowAction) {
-      userProfileDispatcher({ type: "UN_FOLLOW" });
-    } else {
-      userProfileDispatcher({ type: "FOLLOW" });
-    }
+    userProfileDispatcher({
+      type: isDeleteFollowAction ? "UN_FOLLOW" : "FOLLOW",
+    });
 
     const isFolloweeTab = state.tab === "followee";
     const copiedValue = [...followProfiles.value];
@@ -134,10 +133,10 @@ const Follow = () => {
             tagList={userProfile.tags}
             categoryList={userProfile.categories}
             getCategoryData={(category: string) => {
-              router.push(`/my/category?category=${category}`);
+              router.push(`${LINKOCEAN_PATH.myCategory}?category=${category}`);
             }}
             getTagsData={(tags: string[]) => {
-              router.push(`/my/tag?tags=${tags[0]}`);
+              router.push(`${LINKOCEAN_PATH.myCategory}?tags=${tags[0]}`);
             }}
           />
         </PageLayout.Aside>

--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -15,6 +15,7 @@ import profileAPI from "@/utils/apis/profile";
 import { getQueryString } from "@/utils/queryString";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
 import { useProfileDispatch, useProfileState } from "@/hooks/useProfile";
+import { LINKOCEAN_PATH } from "@/utils/constants";
 
 const PAGE_SIZE = 8;
 
@@ -65,13 +66,11 @@ const Follow = () => {
       isFollow: !userProfile.isFollow,
     });
 
-    const nextFolloweeCount = isDeleteFollowAction
-      ? myProfile.followeeCount - 1
-      : myProfile.followeeCount + 1;
-    myProfileDispatcher({
-      type: "GET_PROFILES",
-      profile: { ...myProfile, followeeCount: nextFolloweeCount },
-    });
+    if (isDeleteFollowAction) {
+      myProfileDispatcher({ type: "UN_FOLLOW" });
+    } else {
+      myProfileDispatcher({ type: "FOLLOW" });
+    }
 
     if (state.tab === "follower") {
       const { profileId, imageUrl, username, isFollow } = myProfile;
@@ -97,11 +96,9 @@ const Follow = () => {
     );
 
     const isDeleteFollowAction = followProfiles.value[index].isFollow;
-    if (isDeleteFollowAction) {
-      myProfileDispatcher({ type: "UN_FOLLOW" });
-    } else {
-      myProfileDispatcher({ type: "FOLLOW" });
-    }
+    myProfileDispatcher({
+      type: isDeleteFollowAction ? "UN_FOLLOW" : "FOLLOW",
+    });
 
     const copiedValue = [...followProfiles.value];
     copiedValue[index].isFollow = !copiedValue[index].isFollow;
@@ -178,7 +175,7 @@ const Follow = () => {
 
     const queryProfileId = parseInt(router.query.profileId as string, 10);
     if (queryProfileId === myProfile.profileId) {
-      router.push(`/my/follow`);
+      router.push(LINKOCEAN_PATH.myFollow);
     }
 
     getUserProfile();
@@ -209,12 +206,12 @@ const Follow = () => {
                 categoryList={userProfile.categories}
                 getCategoryData={(category) => {
                   router.push(
-                    `/profile/${userProfile.profileId}/category?category=${category}`
+                    `${LINKOCEAN_PATH.other}/${userProfile.profileId}/category?category=${category}`
                   );
                 }}
                 getTagsData={(tags) => {
                   router.push(
-                    `/profile/${userProfile.profileId}/tag?tags=${tags[0]}`
+                    `${LINKOCEAN_PATH.other}/${userProfile.profileId}/tag?tags=${tags[0]}`
                   );
                 }}
               />

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -2,7 +2,6 @@ import {
   ChangeEventHandler,
   FormEvent,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from "react";

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2,7 +2,7 @@
 export const STORAGE_KEY = {
   oauthType: "OAUTH_TYPE",
   token: "LINKOCEAN_TOKEN",
-};
+} as const;
 
 export const LINKOCEAN_PATH = {
   login: "/",
@@ -20,4 +20,4 @@ export const LINKOCEAN_PATH = {
   feed: "/feed",
   feedDetail: "/feed/detail",
   notFound: "/404",
-};
+} as const;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -9,7 +9,7 @@ export const LINKOCEAN_PATH = {
   signup: "/signup",
   myFavorite: "/my/favorite",
   myTag: "/my/tag",
-  myCategory: "my/category",
+  myCategory: "/my/category",
   myFollow: "/my/follow",
   myEdit: "/my/edit",
   myDetail: "/my/detail",


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요
- 라우팅에 사용하는 상대 경로들을 문자열 대신 상수 변수로 변경

# 작업사항
- 마이 카테고리 상대 경로가 잘못 설정되어 있는 문제 수정("my/category" -> "/my/category")
- 회원가입 페이지에 있는 불필요한 import문 제거
- 라우팅에 사용하는 상대 경로들을 문자열 대신 상수 변수로 변경
  - [x] 머구리찾기
  - [x] 마이 팔로잉 페이지
  - [x] 남의 팔로잉 페이지
  - [x] 피드 페이지
  - [x] 로그인 페이지
- 상수들 const assertion하여 readonly로 변경
- 유저 context 업데이트 코드 정리

# 의문
- 코드의 가독성이 더 안 좋아진 것 같은데 기분 탓일까요?

<!-- closes #이슈번호 -->
closes #297 