### PR TITLE
Fix/#312-팔로잉 페이지들에 위로가기 버튼 추가

### DIFF
--- a/pages/my/follow.tsx
+++ b/pages/my/follow.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import styled from "@emotion/styled";
 import MyFilterMenu from "@/components/common/filterMenu/myFilterMenu";
 import FollowRadio from "@/components/follow/followRadio";
-import { Following, UserInfo, PageLayout } from "@/components/common";
+import { Following, UserInfo, PageLayout, Top } from "@/components/common";
 import { Profile } from "@/types/model";
 import profileAPI from "@/utils/apis/profile";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
@@ -185,6 +185,7 @@ const Follow = () => {
                 )
               )}
             </FollowCardContainer>
+            <Top />
           </Layout>
         </PageLayout.Article>
       </PageLayout>

--- a/pages/profile/[profileId]/follow.tsx
+++ b/pages/profile/[profileId]/follow.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { ChangeEvent, useCallback, useEffect, useState } from "react";
-import { PageLayout, UserInfo, Following } from "@/components/common";
+import { PageLayout, UserInfo, Following, Top } from "@/components/common";
 import FollowRadio from "@/components/follow/followRadio";
 import OtherFilterMenu from "@/components/common/filterMenu/otherFilterMenu";
 import {
@@ -265,6 +265,7 @@ const Follow = () => {
                 )
               )}
             </FollowCardContainer>
+            <Top />
           </Layout>
         </PageLayout.Article>
       </PageLayout>


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 팔로잉 페이지들에 위로가기 버튼 추가

# 작업사항
- 마이 팔로잉 페이지
 
  ![image](https://user-images.githubusercontent.com/96400112/184524139-5bf4e880-8ce5-462b-939f-9386d540c49d.png)

- 남의 팔로잉 페이지
  
  ![image](https://user-images.githubusercontent.com/96400112/184524148-e5c92797-b870-4579-bd78-f879e54554e8.png)


<!-- closes #이슈번호 -->
closes #312 