### PR TITLE
Feature/#320-Meta 공통 컴포넌트

### DIFF
--- a/components/common/index.ts
+++ b/components/common/index.ts
@@ -11,6 +11,7 @@ export { default as Header } from "./header";
 export { default as Input } from "./input";
 export { default as Label } from "./label";
 export { default as LogoutTooltip } from "./logoutTooltip";
+export { default as Meta } from "./meta";
 export { default as Modal } from "./modal";
 export { default as MyFilterMenu } from "./filterMenu/myFilterMenu";
 export { default as NoResult } from "./noResult";

--- a/components/common/index.ts
+++ b/components/common/index.ts
@@ -10,6 +10,7 @@ export { default as Following } from "./following";
 export { default as Header } from "./header";
 export { default as Input } from "./input";
 export { default as Label } from "./label";
+export { default as LogoutTooltip } from "./logoutTooltip";
 export { default as Modal } from "./modal";
 export { default as MyFilterMenu } from "./filterMenu/myFilterMenu";
 export { default as NoResult } from "./noResult";

--- a/components/common/meta.tsx
+++ b/components/common/meta.tsx
@@ -1,0 +1,46 @@
+import { RobotsType } from "@/types/type";
+import Head from "next/head";
+import React from "react";
+
+const DEFAULT_OG_ARR = [
+  ["type", "website"],
+  [
+    "image",
+    "https://user-images.githubusercontent.com/96400112/184529588-201f35b8-d176-49fe-834e-eee0f1c3ecad.png",
+  ],
+];
+interface MetaProps {
+  title: string;
+  titleWithoutSuffix?: boolean;
+  description?: string;
+  needOg?: boolean;
+  robots: RobotsType;
+}
+
+const Meta = ({
+  title,
+  titleWithoutSuffix = false,
+  description = "",
+  needOg = false,
+  robots,
+}: MetaProps) => {
+  const headTitle = title + (titleWithoutSuffix ? "" : " | LinkOcean");
+  const ogArr = needOg
+    ? [...DEFAULT_OG_ARR, ["title", headTitle], ["description", description]]
+    : [];
+
+  return (
+    <Head>
+      <title>{headTitle}</title>
+      {description ? <meta name="description" content={description} /> : null}
+      {ogArr.map(([property, content]) =>
+        content === "" ? null : (
+          <meta property={`og:${property}`} content={content} />
+        )
+      )}
+      <meta name="robots" content={robots} />
+    </Head>
+  );
+};
+
+export default Meta;

--- a/types/type.ts
+++ b/types/type.ts
@@ -23,3 +23,9 @@ export type TagType = {
 };
 
 export type Reaction = "like" | "hate";
+
+export type RobotsType =
+  | "noindex, nofollow"
+  | "index, follow"
+  | "noindex, follow"
+  | "index, nofollow";


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- Meta 공통 컴포넌트 구현
# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->

## props
- `title`, string
- `titleWithoutSuffix`, boolean, optional
  - " | LinkOcean" 접미사를 안 붙이도록 설정하는 prop입니다. (로그인 페이지에서는 접미사가 안 붙어서 만든 prop입니다.)
- `description`, string, optional, 기본값 ""
- `needOg`, boolean, optional, 기본값 false
  - true로 설정 시 props로 전달한 title과 description 값으로 동일하게 설정됩니다
- `robots`, RobotsType
  - RobotsType
    ```js
    export type RobotsType =
      | "noindex, nofollow"
      | "index, follow"
      | "noindex, follow"
      | "index, nofollow";
    ```

> og props도 받으려고 했으나 og 태그를 사용하는 페이지들이 title, description과 동일한 것 같아서 `needOg`로 처리했습니다. og props로 받아야 할 것 같다면 알려주세욤

## 사용 예시 (피드 페이지)

```js
<Meta
  title={`${state.searchTitle} 전체 피드 검색`.trim()}
  description={`${
    state.searchTitle !== "" ? `${state.searchTitle}의` : ""
  } 링크오션 전체 피드 검색 결과입니다.`}
  needOg
  robots="index, follow"
/>
```
![image](https://user-images.githubusercontent.com/96400112/184531356-d2f1126c-9333-41d1-a745-6203b1c24a1d.png)

# 그 외
![image](https://user-images.githubusercontent.com/96400112/184531455-090a340c-7711-4be0-b1db-8c7a2b65df9b.png)

- http-equiv 속성은 HTML4에서 사용하고, HTML5에서는 meta=로 사용한다는 군요
- char-set과 viewport는 next.js에서 자동으로 해주는 느낌입니다
- og:image에 사용한 이미지는 1.91:1 비율로 임의로 만들어서 넣었습니다. 공유하기로 어떻게 나오는지 보고 수정하면 될 것 같습니다. (이미지는 #320 댓글에 있습니다)

<!-- closes #이슈번호 -->
closes #320 