### PR TITLE
Fix/#336-피드->디테일->피드 이동 시 필터링 항목들이 초기화되는 문제

### DIFF
--- a/components/common/checkbox.tsx
+++ b/components/common/checkbox.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import * as theme from "@/styles/theme";
 import useToggle from "@/hooks/useToggle";
-import { ChangeEventHandler } from "react";
+import { useEffect, ChangeEventHandler } from "react";
 
 type HandleChange = ChangeEventHandler<HTMLInputElement>;
 export interface CheckboxProps
@@ -22,6 +22,13 @@ const Checkbox = ({ on = false, onChange, ...props }: CheckboxProps) => {
 
     onChange(e);
   };
+
+  useEffect(() => {
+    if (checked !== on) {
+      toggle();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [on]);
 
   return (
     <Container>

--- a/components/common/select/selectStore.tsx
+++ b/components/common/select/selectStore.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   Dispatch,
   SetStateAction,
+  useEffect,
 } from "react";
 
 const INITIAL_OPTION = { value: "", text: "" };
@@ -43,6 +44,12 @@ const SelectProvider = ({
   const [selectedOption, setSelectedOption] = useState(
     props.selectedOption ?? INITIAL_OPTION
   );
+
+  useEffect(() => {
+    if (props.selectedOption) {
+      setSelectedOption(props.selectedOption);
+    }
+  }, [props.selectedOption]);
 
   const handleChange = (newValue: typeof INITIAL_OPTION) => {
     setSelectedOption(newValue);

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -86,12 +86,12 @@ const Feed = () => {
 
   const changeRoutePath = useCallback(
     (nextState: Filtering) => {
-      const { category, searchTitle } = nextState;
-      const queryString =
-        searchTitle === ""
-          ? `category=${category}`
-          : getQueryString({ category, searchTitle });
-      router.push(`${LINKOCEAN_PATH.feed}?${queryString}`);
+      const { size, searchTitle, ...query } = nextState;
+
+      router.push({
+        pathname: LINKOCEAN_PATH.feed,
+        query: searchTitle === "" ? { ...query } : { ...query, searchTitle },
+      });
     },
     [router]
   );
@@ -179,25 +179,17 @@ const Feed = () => {
       return;
     }
 
-    const VALID_KEYS = ["category", "searchTitle"];
-    const isValidQuery =
-      queryKeys.every((key) => VALID_KEYS.includes(key)) &&
-      ["전체", ...CATEGORY].includes(query.category as string);
-
-    if (!isValidQuery) {
-      router.push(LINKOCEAN_PATH.notFound);
-    }
-
     const searchTitle = query.searchTitle as string;
+    const page = parseInt(query.page as string, 10);
+    const follow = (query.follow as string) === "true";
     setIsRouterReady(true);
-    if (searchTitle === "") {
-      setState({
-        ...INITIAL_FILTERING,
-        category: query.category as CategoryType,
-      });
-    } else {
-      setState({ ...INITIAL_FILTERING, ...query });
-    }
+
+    setState({
+      ...INITIAL_FILTERING,
+      ...query,
+      page,
+      follow,
+    });
     setSearchTitleInputValue(searchTitle);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 피드->디테일->피드 이동 시 필터링 항목들이 초기화되는 문제
# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 필터링 항목들 (category, searchTitle, follow, order, page) 값들을 url query string으로 간직하여 해결
- Checkbox, Select 공통 컴포넌트 버그 해결
  - 초기값을 변경해도 반영되지 않는 문제
  - 버그를 고친 후 Checkbox, Select 컴포넌트들을 사용하는 페이지들에서 에러가 발생하지 않는지 확인 후 PR 올렸습니다.

## 데모

https://user-images.githubusercontent.com/96400112/184540922-840e53a5-0089-4fe1-969c-039914676f5f.mp4


<!-- closes #이슈번호 -->
closes #336 