### PR TITLE
Fix/#364-전체 피드 페이지 document.title이 검색어에 따라 분기 처리 되지 않은 문제

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -209,7 +209,9 @@ const Feed = () => {
   return (
     <>
       <Meta
-        title={`${state.searchTitle} - 전체 피드 검색`.trim()}
+        title={`${
+          state.searchTitle !== "" ? `${state.searchTitle} -` : ""
+        } 전체 피드 검색`.trim()}
         description={`${
           state.searchTitle !== "" ? `${state.searchTitle} -` : ""
         } LinkOcean 전체 피드 검색 결과입니다.`.trim()}


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 전체 피드 페이지에서 검색어를 입력하지 않았음에도 `- 전체 피드 검색 | LinkOcean`로 표시되는 문제 수정
![image](https://user-images.githubusercontent.com/96400112/187106005-29cd8280-ade5-44de-bc2e-aa831e7ee9a0.png)

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 검색어가 입력되지 않았으면 `전체 피드 검색 | LinkOcean`, 검색어로 검색을 했다면 `검색어 - 전체 피드 검색 | LinkOcean`으로 분기 처리
![feed title fix](https://user-images.githubusercontent.com/96400112/187106313-db4afca0-b9ca-4a3a-a903-22cfef3c23f7.gif)


<!-- closes #이슈번호 -->
closes #364 