### PR TITLE
Feature/#376-Select 공통 컴포넌트 버전2 디자인 추가

### DIFF
--- a/components/common/select/optionList.tsx
+++ b/components/common/select/optionList.tsx
@@ -8,23 +8,34 @@ interface OptionListProps extends React.HTMLAttributes<HTMLUListElement> {
 
 const OptionList = ({ maxHeight, ...props }: OptionListProps) => {
   const {
-    style: { width },
+    style: { width, version2 },
     state: { open },
   } = useSelect();
 
-  return open ? <StyledList style={{ width, maxHeight }} {...props} /> : null;
+  return open ? (
+    <StyledList style={{ width, maxHeight }} version2={version2} {...props} />
+  ) : null;
 };
 
 export default OptionList;
 
-const StyledList = styled.ul`
+const StyledList = styled.ul<{ version2: boolean }>`
   display: flex;
   flex-direction: column;
   gap: 5px;
   position: absolute;
-  border: 1px solid ${theme.color.$gray600};
+  ${({ version2 }) =>
+    version2
+      ? `
+          top: calc(100% + 9px);
+          left: 2px;
+          box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.15);
+        `
+      : null}
+  border: ${({ version2 }) =>
+    version2 ? 0 : `1px solid ${theme.color.$gray600}`};
   border-top: 0;
-  border-radius: 0 0 8px 8px;
+  border-radius: ${({ version2 }) => (version2 ? "8px" : "0 0 8px 8px")};
   padding: 8px 0;
   background-color: #fff;
   z-index: 10;

--- a/components/common/select/select.tsx
+++ b/components/common/select/select.tsx
@@ -10,6 +10,7 @@ const Select = ({
   selectedOption,
   children,
   onChange,
+  version2,
 }: Partial<SelectProviderProps>) => {
   return (
     <SelectProvider
@@ -17,6 +18,7 @@ const Select = ({
       open={open}
       selectedOption={selectedOption}
       onChange={onChange}
+      version2={version2}
     >
       <Container>{children}</Container>
     </SelectProvider>

--- a/components/common/select/selectStore.tsx
+++ b/components/common/select/selectStore.tsx
@@ -10,7 +10,7 @@ import React, {
 const INITIAL_OPTION = { value: "", text: "" };
 
 interface SelectContextProps {
-  style: { width: string };
+  style: { width: string; version2: boolean };
   state: {
     open: boolean;
     selectedOption: typeof INITIAL_OPTION;
@@ -30,6 +30,7 @@ export interface SelectProviderProps {
   open?: boolean;
   selectedOption?: typeof INITIAL_OPTION;
   width?: string;
+  version2?: boolean;
   onChange?: (value: string) => void;
   children: React.ReactNode;
 }
@@ -38,6 +39,7 @@ const SelectProvider = ({
   width = "120px",
   children,
   onChange,
+  version2 = false,
   ...props
 }: SelectProviderProps) => {
   const [open, setOpen] = useState(props.open ?? false);
@@ -61,7 +63,7 @@ const SelectProvider = ({
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value = {
-    style: { width },
+    style: { width, version2 },
     state: { open, selectedOption },
     actions: { setOpen, handleChange },
   };

--- a/components/common/select/trigger.tsx
+++ b/components/common/select/trigger.tsx
@@ -7,7 +7,7 @@ const Trigger = ({
   ...props
 }: React.HTMLAttributes<HTMLButtonElement>) => {
   const {
-    style: { width },
+    style: { width, version2 },
     state: { open, selectedOption },
     actions: { setOpen },
   } = useSelect();
@@ -18,6 +18,7 @@ const Trigger = ({
       open={open}
       style={{ width }}
       onClick={() => setOpen(() => !open)}
+      version2={version2}
       {...props}
     >
       {selectedOption.text !== "" ? selectedOption.text : children}
@@ -25,19 +26,45 @@ const Trigger = ({
   );
 };
 
-const StyledButton = styled.button<{ open: boolean }>`
+const version2Filter =
+  "brightness(0) saturate(100%) invert(100%) sepia(4%) saturate(338%) hue-rotate(243deg) brightness(118%) contrast(92%)";
+
+const StyledButton = styled.button<{ open: boolean; version2: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
   height: 44px;
-  border: 1px solid ${theme.color.$gray600};
-  border-radius: ${(props) => (props.open ? "8px 8px 0 0" : "8px")};
+  border: ${({ version2 }) =>
+    version2 ? 0 : `1px solid ${theme.color.$gray600}`};
+  border-radius: ${({ open, version2 }) =>
+    open && !version2 ? "8px 8px 0 0" : "8px"};
   padding: 10px 15px;
-  color: ${theme.color.$gray600};
-  background-color: #fff;
+  color: ${({ open, version2 }) =>
+    open && version2 ? theme.color.$gray50 : theme.color.$gray600};
+  background-color: ${({ open, version2 }) =>
+    open && version2 ? theme.color.$skyBlue : "#fff"};
   ${theme.text.$body1};
   text-align: start;
   cursor: pointer;
+
+  &:hover {
+    ${({ version2 }) =>
+      version2
+        ? `
+      color: ${theme.color.$gray50};
+      background-color: ${theme.color.$skyBlue};
+    `
+        : null}
+  }
+
+  &:hover::after {
+    ${({ version2 }) =>
+      version2
+        ? `
+      filter: ${version2Filter};
+    `
+        : null}
+  }
 
   &::after {
     content: "";
@@ -46,6 +73,8 @@ const StyledButton = styled.button<{ open: boolean }>`
     height: 8px;
     background: url("/icon/select-arrow.svg") center;
     transform: ${(props) => (props.open ? " rotate(180deg)" : null)};
+    filter: ${({ open, version2 }) =>
+      open && version2 ? version2Filter : null};
   }
 `;
 

--- a/stories/components/select.stories.tsx
+++ b/stories/components/select.stories.tsx
@@ -1,5 +1,7 @@
 import Select from "@/components/common/select";
 import { useState } from "react";
+import * as theme from "@/styles/theme";
+import styled from "@emotion/styled";
 
 export default {
   title: "Components/Select",
@@ -82,4 +84,25 @@ export const Scroll = ({
 Scroll.argTypes = {
   maxHeight: { control: { type: "text" }, defaultValue: "100px" },
   width: { control: { type: "text" }, defaultValue: "100px" },
+};
+
+export const Version2 = () => {
+  const categories = ["전체", "자기계발", "예술"];
+  return (
+    <Select
+      width="127px"
+      selectedOption={{ value: "전체", text: "전체" }}
+      onChange={(category) => alert(category)}
+      version2
+    >
+      <Select.Trigger>선택</Select.Trigger>
+      <Select.OptionList>
+        {categories.map((category) => (
+          <Select.Option value={category} key={category}>
+            {category}
+          </Select.Option>
+        ))}
+      </Select.OptionList>
+    </Select>
+  );
 };


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- `Select` 공통 컴포넌트 디자인 버전 2 추가 

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- `Select` 컴포넌트에 옵셔널 `boolean` 타입의  `props.version2` 추가
    ```js
    <Select version2>
      ...
    </Select>
    ```

스토리북 **_Version2_**

![select version2](https://user-images.githubusercontent.com/96400112/188281046-7a64e5b1-415b-4449-a82a-1dfaa0604d03.gif)


# 관련 이슈
- 기존 디자인과 추가된 디자인 2개를 컴포넌트 단에서 어떻게 설계할까 고민하다 기동 멘토님한테 물어봤습니다. 아주 의외의 대답을 들었습니다. **추가된 디자인으로 통일해라!** 다른 분들의 의견이 궁금합니다!

<!-- closes #이슈번호 -->
closes #376 