### PR TITLE
[#382] style: Input 공통 컴포넌트 검색 아이콘 오른쪽 배치 prop 추가

### DIFF
--- a/components/common/input.tsx
+++ b/components/common/input.tsx
@@ -5,6 +5,7 @@ import { forwardRef } from "react";
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   searchIcon?: boolean;
+  endIcon?: boolean;
   width?: string;
   height?: string;
 }
@@ -13,6 +14,7 @@ const Input = forwardRef(
   (
     {
       searchIcon = false,
+      endIcon = false,
       width = "367px",
       height = "45px",
       ...props
@@ -20,14 +22,8 @@ const Input = forwardRef(
     ref?: React.Ref<HTMLInputElement>
   ) => {
     return searchIcon ? (
-      <SearchInput>
-        <img
-          src="/icon/search.svg"
-          alt="search"
-          aria-hidden
-          width={24}
-          height={24}
-        />
+      <SearchInput endIcon={endIcon} width={width}>
+        <img src="/icon/search.svg" alt="" width={24} height={24} />
         <DefaultInput
           placeholder="검색어를 입력해주세요."
           width={width}
@@ -66,18 +62,19 @@ const DefaultInput = styled.input`
   }
 `;
 
-const SearchInput = styled.div`
+const SearchInput = styled.div<{ width: string; endIcon: boolean }>`
   position: relative;
 
   img {
     position: absolute;
     top: 50%;
-    left: 12px;
+    left: ${({ width, endIcon }) =>
+      endIcon ? `calc(${width} - 24px - 17px)` : "12px"};
     transform: translateY(-50%);
   }
 
   input {
-    padding-left: 48px;
+    padding-left: ${({ endIcon }) => (endIcon ? "17px" : "48px")};
   }
 `;
 

--- a/stories/components/input.stories.tsx
+++ b/stories/components/input.stories.tsx
@@ -5,7 +5,10 @@ export default {
   title: "Components/Input",
   component: Input,
   argTypes: {
+    width: { control: "text", defaultValue: "367px" },
+    height: { control: "text", defaultValue: "45px" },
     searchIcon: { control: "boolean", defaultValue: false },
+    endIcon: { control: "boolean", defaultValue: false },
   },
 };
 
@@ -20,7 +23,7 @@ export const StyleCustom = (args: InputProps) => (
 );
 StyleCustom.parameters = {
   controls: {
-    exclude: "searchIcon",
+    exclude: ["searchIcon", "endIcon"],
   },
 };
 
@@ -41,7 +44,7 @@ export const WithState = (args: InputProps) => {
 };
 WithState.parameters = {
   controls: {
-    exclude: "searchIcon",
+    exclude: ["searchIcon", "endIcon"],
   },
 };
 
@@ -59,6 +62,6 @@ export const WithRef = (args: InputProps) => {
 };
 WithRef.parameters = {
   controls: {
-    exclude: "searchIcon",
+    exclude: ["searchIcon", "endIcon"],
   },
 };


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- [x] Input 공통 컴포넌트 검색 아이콘 위치 변경 prop 추가
  - props.endIcon, optional, boolean, 기본값 false

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->

스토리북 **_Default_**
![input 검색 아이콘 오른쪽 배치](https://user-images.githubusercontent.com/96400112/188283374-04e9f828-bfa2-4329-8e2a-45b166307c2b.gif)

# 사용 방법
- @dbckdgjs369 기존 Input 컴포넌트 디자인에는 `border`가 있어 아래처럼 인라인 스타일로 없애서 사용하면 될 것 같습니다.
```js
<Input width="272px" searchIcon endIcon style={{ border: 0 }}/>
```

![image](https://user-images.githubusercontent.com/96400112/188283422-b76b7708-4ae8-4ac8-9608-9824c6b1d20f.png)


<!-- closes #이슈번호 -->
closes #382 
