### PR TITLE
Fix/#388-피드페이지 팔로워 게시글만 필터링 제거

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -37,7 +37,6 @@ type OrderType = "upload" | "like";
 type Filtering = {
   category: CategoryType;
   searchTitle: string;
-  follow: boolean;
   order: OrderType;
   page: number;
   size: number;
@@ -46,7 +45,6 @@ type Filtering = {
 const INITIAL_FILTERING: Filtering = {
   category: "전체",
   searchTitle: "",
-  follow: false,
   order: "upload",
   page: 1,
   size: PAGE_SIZE,
@@ -99,15 +97,6 @@ const Feed = () => {
   const handleChangeState = (nextState: Filtering) => {
     setState(nextState);
     changeRoutePath(nextState);
-  };
-  const handleChangeFollow = ({
-    target: { checked },
-  }: ChangeEvent<HTMLInputElement>) => {
-    handleChangeState({
-      ...state,
-      page: INITIAL_FILTERING.page,
-      follow: checked,
-    });
   };
 
   const handleChangeCategory = (selectedCategory: string) => {
@@ -181,14 +170,12 @@ const Feed = () => {
 
     const searchTitle = query.searchTitle as string;
     const page = parseInt(query.page as string, 10);
-    const follow = (query.follow as string) === "true";
     setIsRouterReady(true);
 
     setState({
       ...INITIAL_FILTERING,
       ...query,
       page,
-      follow,
     });
     setSearchTitleInputValue(searchTitle);
 
@@ -244,6 +231,7 @@ const Feed = () => {
                   ref={searchTitleRef}
                   value={searchTitleInputValue}
                   onChange={(e) => setSearchTitleInputValue(e.target.value)}
+                  autoFocus
                 />
                 <Button
                   colorType="main-color"
@@ -255,38 +243,19 @@ const Feed = () => {
                 </Button>
               </SearchTitle>
 
-              <FormRight>
-                <Follow>
-                  <Label
-                    htmlFor="follow"
-                    style={{ userSelect: "none", cursor: "pointer" }}
-                  >
-                    팔로워 게시글만
-                  </Label>
-                  <Checkbox
-                    name="follow"
-                    id="follow"
-                    on={state.follow}
-                    onChange={handleChangeFollow}
-                  />
-                </Follow>
-
-                <div>
-                  <Select
-                    onChange={handleChangeOrder}
-                    selectedOption={{
-                      value: state.order,
-                      text: state.order === "upload" ? "최신 순" : "좋아요 순",
-                    }}
-                  >
-                    <Select.Trigger>정렬</Select.Trigger>
-                    <Select.OptionList>
-                      <Select.Option value="upload">최신 순</Select.Option>
-                      <Select.Option value="like">좋아요 순</Select.Option>
-                    </Select.OptionList>
-                  </Select>
-                </div>
-              </FormRight>
+              <Select
+                onChange={handleChangeOrder}
+                selectedOption={{
+                  value: state.order,
+                  text: state.order === "upload" ? "최신 순" : "좋아요 순",
+                }}
+              >
+                <Select.Trigger>정렬</Select.Trigger>
+                <Select.OptionList>
+                  <Select.Option value="upload">최신 순</Select.Option>
+                  <Select.Option value="like">좋아요 순</Select.Option>
+                </Select.OptionList>
+              </Select>
             </Form>
 
             <BookmarkContainer>
@@ -341,18 +310,6 @@ const Form = styled.form`
 const SearchTitle = styled.div`
   display: flex;
   gap: 10px;
-`;
-
-const FormRight = styled.div`
-  display: flex;
-  gap: 27px;
-`;
-
-const Follow = styled.div`
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  gap: 12px;
 `;
 
 const BookmarkContainer = styled.div`


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 북마크 공개 범위에 대한 정책 변경 사항 반영
# 작업사항
- 피드 페이지 작업
  - [x] 팔로워 게시글만 체크박스 삭제
    
    ![image](https://user-images.githubusercontent.com/96400112/189405193-e3f5333b-2208-4304-bef9-96c3c8f96e42.png)
- type/types.ts 
  - [ ] `export type OpenType = "private" | "all" | "partial";` partial 삭제 ❌

# 관련 이슈

<!-- 아직 구현되지 않은 기능들, 기능 구현하다 실패한 점, 테스트할 때 유의할 점? -->
- type/types.ts `OpenType`에서 partial 제거하면, **북마크 생성**과 **수정** 페이지 그리고 **북마크 카드 컴포넌트**에서 에러가 발생하여 빌드가 안 됩니다. @jieun0411 랑 @NamgyungKim  중에 가장 마지막에 작업하시는 분이 제거하면 될 것 같습니다.

<!-- closes #이슈번호 -->
closes #388 