### PR TITLE
Feat/#394-selectCheckbox 컴포넌트 추가

### DIFF
--- a/components/common/index.ts
+++ b/components/common/index.ts
@@ -28,3 +28,4 @@ export { default as Star } from "./star";
 export { default as Textarea } from "./textarea";
 export { default as Top } from "./top";
 export { default as UserInfo } from "./userInfo";
+export { default as SelectCheckbox } from "./selectCheckbox";

--- a/components/common/selectCheckbox.tsx
+++ b/components/common/selectCheckbox.tsx
@@ -42,7 +42,7 @@ const SelectCheckbox = ({
           {tags.map(({ tag, count }) => (
             <List key={tag} onClick={clickList} data-tag={tag}>
               <span>
-                # {tag} ({count})
+                # {tag} ({count > 99 ? "99+" : count})
               </span>
               <Checkbox on={checkedList.indexOf(tag) !== -1} />
             </List>

--- a/components/common/selectCheckbox.tsx
+++ b/components/common/selectCheckbox.tsx
@@ -15,7 +15,7 @@ const SelectCheckbox = ({
   checkedList: string[];
   setCheckedList: (tag: string[]) => void;
 }) => {
-  const [selectState, toggle] = useToggle(false);
+  const [selectState, toggle] = useToggle(true);
 
   const clickList = (e: React.MouseEvent<HTMLLIElement>) => {
     const tag = e.currentTarget.getAttribute("data-tag");
@@ -33,7 +33,7 @@ const SelectCheckbox = ({
 
   return (
     <Wrap>
-      <Button {...props} onClick={toggle}>
+      <Button {...props} toggle={selectState} onClick={toggle}>
         태그 선택
         <span>{checkedList.length}</span>
       </Button>
@@ -59,17 +59,21 @@ const Wrap = styled.div`
 
 const Button = styled.button`
   border: none;
-  background-color: ${color.$skyBlue};
-  color: #fff;
+  background-color: ${({ toggle }: { toggle: boolean }) =>
+    toggle ? color.$skyBlue : "#fff"};
+  color: ${({ toggle }: { toggle: boolean }) =>
+    toggle ? "#fff" : color.$gray600};
   height: 44px;
   padding: 0 11px;
   border-radius: 8px;
   ${text.$subtitle1}
   cursor: pointer;
   :hover {
-    background-color: ${color.$hoverSkyBlue};
+    background-color: ${({ toggle }: { toggle: boolean }) =>
+      toggle ? color.$hoverSkyBlue : "#eee"};
     span {
-      color: ${color.$hoverSkyBlue};
+      color: ${({ toggle }: { toggle: boolean }) =>
+        toggle ? color.$hoverSkyBlue : color.$gray600};
     }
   }
   span {
@@ -78,7 +82,8 @@ const Button = styled.button`
     padding: 3px 6px;
     border-radius: 26px;
     background-color: #fff;
-    color: ${color.$skyBlue};
+    color: ${({ toggle }: { toggle: boolean }) =>
+      toggle ? color.$skyBlue : color.$gray600};
     margin-left: 8px;
     box-sizing: border-box;
   }
@@ -86,23 +91,27 @@ const Button = styled.button`
 
 const ListBox = styled.ul`
   position: absolute;
-  left: 0;
-
+  left: 2px;
   width: 220px;
   max-height: 280px;
+  margin-top: 9px;
+  padding: 10px 0;
   overflow-y: auto;
   border: 1px solid ${color.$gray100};
   border-radius: 8px;
   box-shadow: 0px 10px 10px rgba(0, 0, 0, 0.15);
-  margin-top: 10px;
+  background-color: #fff;
+  overflow: overlay;
+
+  &::-webkit-scrollbar {
+    width: 11px;
+  }
+
   &::-webkit-scrollbar-thumb {
     border-radius: 6px;
     background-color: ${color.$mainColor};
     background-clip: padding-box;
     border: 4px solid transparent;
-  }
-  &::-webkit-scrollbar {
-    width: 10px;
   }
 `;
 
@@ -111,11 +120,13 @@ const List = styled.li`
   background-color: #fff;
   justify-content: space-between;
   align-items: center;
-  height: 37px;
+  height: 32px;
   padding: 0 15px;
+  margin: 5px 0;
+  color: ${color.$gray600};
   cursor: pointer;
   :hover {
-    background-color: ${color.$gray100};
+    background-color: #88bedf20;
   }
 `;
 

--- a/components/common/selectCheckbox.tsx
+++ b/components/common/selectCheckbox.tsx
@@ -1,0 +1,122 @@
+import useToggle from "@/hooks/useToggle";
+import { color, text } from "@/styles/theme";
+import { TagType } from "@/types/type";
+import styled from "@emotion/styled";
+import React from "react";
+import Checkbox from "./checkbox";
+
+const SelectCheckbox = ({
+  tags,
+  checkedList,
+  setCheckedList,
+  ...props
+}: {
+  tags: TagType[];
+  checkedList: string[];
+  setCheckedList: (tag: string[]) => void;
+}) => {
+  const [selectState, toggle] = useToggle(false);
+
+  const clickList = (e: React.MouseEvent<HTMLLIElement>) => {
+    const tag = e.currentTarget.getAttribute("data-tag");
+    if (!tag) return;
+    const tagIndex = checkedList.indexOf(tag);
+    if (tagIndex === -1) {
+      setCheckedList([...checkedList, tag]);
+    } else {
+      const tagList = [...checkedList];
+      tagList.splice(tagIndex, 1);
+      setCheckedList(tagList);
+    }
+    e.preventDefault();
+  };
+
+  return (
+    <Wrap>
+      <Button {...props} onClick={toggle}>
+        태그 선택
+        <span>{checkedList.length}</span>
+      </Button>
+      {selectState ? (
+        <ListBox>
+          {tags.map(({ tag, count }) => (
+            <List key={tag} onClick={clickList} data-tag={tag}>
+              <span>
+                # {tag}({count})
+              </span>
+              <Checkbox on={checkedList.indexOf(tag) !== -1} />
+            </List>
+          ))}
+        </ListBox>
+      ) : null}
+    </Wrap>
+  );
+};
+
+const Wrap = styled.div`
+  position: relative;
+`;
+
+const Button = styled.button`
+  border: none;
+  background-color: ${color.$skyBlue};
+  color: #fff;
+  height: 44px;
+  padding: 0 11px;
+  border-radius: 8px;
+  ${text.$subtitle1}
+  cursor: pointer;
+  :hover {
+    background-color: ${color.$hoverSkyBlue};
+    span {
+      color: ${color.$hoverSkyBlue};
+    }
+  }
+  span {
+    display: inline-block;
+    min-width: 26px;
+    padding: 3px 6px;
+    border-radius: 26px;
+    background-color: #fff;
+    color: ${color.$skyBlue};
+    margin-left: 8px;
+    box-sizing: border-box;
+  }
+`;
+
+const ListBox = styled.ul`
+  position: absolute;
+  left: 0;
+
+  width: 220px;
+  max-height: 280px;
+  overflow-y: auto;
+  border: 1px solid ${color.$gray100};
+  border-radius: 8px;
+  box-shadow: 0px 10px 10px rgba(0, 0, 0, 0.15);
+  margin-top: 10px;
+  &::-webkit-scrollbar-thumb {
+    border-radius: 6px;
+    background-color: ${color.$mainColor};
+    background-clip: padding-box;
+    border: 4px solid transparent;
+  }
+  &::-webkit-scrollbar {
+    width: 10px;
+  }
+`;
+
+const List = styled.li`
+  display: flex;
+  background-color: #fff;
+  justify-content: space-between;
+  align-items: center;
+  height: 37px;
+  padding: 0 15px;
+  cursor: pointer;
+  :hover {
+    background-color: ${color.$gray100};
+  }
+`;
+
+export default SelectCheckbox;

--- a/components/common/selectCheckbox.tsx
+++ b/components/common/selectCheckbox.tsx
@@ -15,7 +15,7 @@ const SelectCheckbox = ({
   checkedList: string[];
   setCheckedList: (tag: string[]) => void;
 }) => {
-  const [selectState, toggle] = useToggle(true);
+  const [selectState, toggle] = useToggle(false);
 
   const clickList = (e: React.MouseEvent<HTMLLIElement>) => {
     const tag = e.currentTarget.getAttribute("data-tag");
@@ -42,7 +42,7 @@ const SelectCheckbox = ({
           {tags.map(({ tag, count }) => (
             <List key={tag} onClick={clickList} data-tag={tag}>
               <span>
-                # {tag}({count})
+                # {tag} ({count})
               </span>
               <Checkbox on={checkedList.indexOf(tag) !== -1} />
             </List>
@@ -67,6 +67,8 @@ const Button = styled.button`
   padding: 0 11px;
   border-radius: 8px;
   ${text.$subtitle1}
+  font-weight: ${({ toggle }: { toggle: boolean }) =>
+    toggle ? "bold" : "normal"};
   cursor: pointer;
   :hover {
     background-color: ${({ toggle }: { toggle: boolean }) =>
@@ -123,10 +125,12 @@ const List = styled.li`
   height: 32px;
   padding: 0 15px;
   margin: 5px 0;
-  color: ${color.$gray600};
   cursor: pointer;
   :hover {
     background-color: #88bedf20;
+  }
+  span {
+    color: ${color.$gray600};
   }
 `;
 

--- a/stories/components/selectCheckbox.stories.tsx
+++ b/stories/components/selectCheckbox.stories.tsx
@@ -1,4 +1,4 @@
-import SelectCheckbox from "@/components/common/selectCheckbox";
+import { SelectCheckbox } from "@/components/common";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { useState } from "react";
 

--- a/stories/components/selectCheckbox.stories.tsx
+++ b/stories/components/selectCheckbox.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { useState } from "react";
 
 export default {
-  title: "components/selectCheckbox",
+  title: "components/SelectCheckbox",
   component: SelectCheckbox,
   argTypes: {},
 } as ComponentMeta<typeof SelectCheckbox>;

--- a/stories/components/selectCheckbox.stories.tsx
+++ b/stories/components/selectCheckbox.stories.tsx
@@ -1,0 +1,59 @@
+import SelectCheckbox from "@/components/common/selectCheckbox";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { useState } from "react";
+
+export default {
+  title: "components/selectCheckbox",
+  component: SelectCheckbox,
+  argTypes: {},
+} as ComponentMeta<typeof SelectCheckbox>;
+
+const tags = [
+  {
+    tag: "태그 입니다",
+    count: 12,
+  },
+  {
+    tag: "라이브러리",
+    count: 11,
+  },
+  {
+    tag: "공부",
+    count: 1,
+  },
+  {
+    tag: "IT",
+    count: 148,
+  },
+  {
+    tag: "즐겨찾기",
+    count: 12,
+  },
+  {
+    tag: "즐겨찾기1",
+    count: 12,
+  },
+  {
+    tag: "즐겨찾기2",
+    count: 12,
+  },
+  {
+    tag: "즐겨찾기3",
+    count: 12,
+  },
+];
+
+export const Default: ComponentStory<typeof SelectCheckbox> = () => {
+  const [checkedList, setCheckedList] = useState(["공부", "즐겨찾기"]);
+
+  return (
+    <>
+      <SelectCheckbox
+        checkedList={checkedList}
+        setCheckedList={setCheckedList}
+        tags={tags}
+      />
+      <p>{checkedList.join(",")}</p>
+    </>
+  );
+};


### PR DESCRIPTION
# 개요
selectCheckbox 컴포넌트 추가

# 작업사항
- props로 태그목록과 해당 선택한 태그 목록을 상위에 제공해주기위한 state,setState를 받습니다.
- 추후 하단에 `태그 X` 를 만드실때 해당 checkedList 배열을 변경해주시면 될 것 같습니다.
```js
export const Default: ComponentStory<typeof SelectCheckbox> = () => {
  const [checkedList, setCheckedList] = useState(["공부", "즐겨찾기"]); 

  return (
    <>
      <SelectCheckbox
        checkedList={checkedList}
        setCheckedList={setCheckedList}
        tags={tags}
      />
      <p>{checkedList.join(",")}</p>
    </>
  );
};
```
![Animation](https://user-images.githubusercontent.com/87519250/191668164-20ccd44e-1ac2-4fca-bc01-8587131fc136.gif)

추가수정 2022.09.27
- 글자 색 -gray600
- 태그 선택 active
- hover
- 스크롤바
- gap - 5px 위아래 10px
- left - 2px
- 버튼과 select 사이 - 9px
- title: "components/selectCheckbox"

추가수정 2022.09.28
- tag count가 100이상일 경우 99+로 표기
- list color 수정 
- # {tag} ({count}) 태그랑 카운트 사이에 띄어쓰기
- common/index.ts 파일에 export, import문이 추가
- toggle전에 font-weight: normal

closes #394
