### PR TITLE
Feature/#402-피드 페이지 버전2 디자인 반영

### DIFF
--- a/components/common/noResult.tsx
+++ b/components/common/noResult.tsx
@@ -17,7 +17,6 @@ const Container = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 835px;
   height: 420px;
   opacity: 0.7;
 `;

--- a/components/myBookmark/bookmarkTemplate.tsx
+++ b/components/myBookmark/bookmarkTemplate.tsx
@@ -321,7 +321,7 @@ export const ContentDiv = styled.div`
 export const PaginationDiv = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: 26px;
+  margin-top: 105px;
 `;
 
 export default MyBookmark;

--- a/components/myBookmark/bookmarkTemplate.tsx
+++ b/components/myBookmark/bookmarkTemplate.tsx
@@ -26,8 +26,7 @@ import {
   BaseQueryType,
 } from "@/types/type";
 import { getQueryString } from "@/utils/queryString";
-
-const PAGE_SIZE = 8;
+import { PAGE_SIZE } from "@/utils/constants";
 
 interface MyBookmarkProps {
   type: FilterKeyType;

--- a/components/otherBookmark/otherBookmarkTemplate.tsx
+++ b/components/otherBookmark/otherBookmarkTemplate.tsx
@@ -12,7 +12,7 @@ import {
 import { useRouter } from "next/router";
 import bookmarkAPI from "@/utils/apis/bookmark";
 import { BookmarkList, ProfileDetail } from "@/types/model";
-import { LINKOCEAN_PATH } from "@/utils/constants";
+import { LINKOCEAN_PATH, PAGE_SIZE } from "@/utils/constants";
 import {
   BaseQueryType,
   CategoryQueryType,
@@ -32,8 +32,6 @@ import {
   Title,
   Wrapper,
 } from "../myBookmark/bookmarkTemplate";
-
-const PAGE_SIZE = 8;
 
 interface OtherBookmarkProps {
   otherProfile: ProfileDetail;

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -1,48 +1,32 @@
 import { useRouter } from "next/router";
-import {
-  ChangeEvent,
-  FormEvent,
-  useState,
-  useEffect,
-  useCallback,
-  useRef,
-} from "react";
+import { FormEvent, useState, useEffect, useCallback, useRef } from "react";
 import styled from "@emotion/styled";
 import {
   Input,
   PageLayout,
-  Button,
-  Label,
-  Checkbox,
   Select,
   Pagination,
   BookmarkCard,
   NoResult,
   Meta,
+  CardWrap,
 } from "@/components/common";
-import FeedFilterMenu from "@/components/common/filterMenu/feedFilterMenu";
 import { BookmarkList } from "@/types/model";
-import { CATEGORY } from "@/types/type";
+import { CATEGORY, CategoryQueryType, SortType } from "@/types/type";
 import { useProfileState } from "@/hooks/useProfile";
 import bookmarkAPI from "@/utils/apis/bookmark";
 import { getQueryString } from "@/utils/queryString";
-import { LINKOCEAN_PATH } from "@/utils/constants";
-import * as theme from "@/styles/theme";
+import { LINKOCEAN_PATH, PAGE_SIZE } from "@/utils/constants";
 
-const PAGE_SIZE = 8;
+import {
+  FilterDiv,
+  PaginationDiv,
+  SubFilterDiv,
+  Title,
+  Wrapper,
+} from "@/components/myBookmark/bookmarkTemplate";
 
-type CategoryType = "전체" | typeof CATEGORY[number];
-type OrderType = "upload" | "like";
-
-type Filtering = {
-  category: CategoryType;
-  searchTitle: string;
-  order: OrderType;
-  page: number;
-  size: number;
-};
-
-const INITIAL_FILTERING: Filtering = {
+const INITIAL_FILTERING: CategoryQueryType = {
   category: "전체",
   searchTitle: "",
   order: "upload",
@@ -54,7 +38,7 @@ const Feed = () => {
   const router = useRouter();
 
   const { profileId } = useProfileState();
-  const [state, setState] = useState<Filtering>(INITIAL_FILTERING);
+  const [state, setState] = useState<CategoryQueryType>(INITIAL_FILTERING);
   const [feedBookmarks, setFeedBookmarks] = useState<BookmarkList>({
     totalCount: 0,
     bookmarks: [],
@@ -70,7 +54,7 @@ const Feed = () => {
     }
     setSearchTitleInputValue(state.searchTitle);
 
-    const query: Partial<Filtering> = { ...state };
+    const query: Partial<CategoryQueryType> = { ...state };
     if (query.category === "전체") {
       delete query.category;
     }
@@ -83,7 +67,7 @@ const Feed = () => {
   }, [state, isRouterReady]);
 
   const changeRoutePath = useCallback(
-    (nextState: Filtering) => {
+    (nextState: CategoryQueryType) => {
       const { size, searchTitle, ...query } = nextState;
 
       router.push({
@@ -94,29 +78,19 @@ const Feed = () => {
     [router]
   );
 
-  const handleChangeState = (nextState: Filtering) => {
+  const handleChanges = (
+    value: string | number | string[],
+    name: keyof CategoryQueryType
+  ) => {
+    if (state[name] === value) {
+      return;
+    }
+
+    const nextState = { ...state, page: 1, [name]: value };
     setState(nextState);
     changeRoutePath(nextState);
   };
 
-  const handleChangeCategory = (selectedCategory: string) => {
-    handleChangeState({
-      ...state,
-      searchTitle: INITIAL_FILTERING.searchTitle,
-      page: INITIAL_FILTERING.page,
-      category: selectedCategory as CategoryType,
-    });
-  };
-  const handleChangeOrder = (selectedOrder: string) => {
-    handleChangeState({
-      ...state,
-      page: INITIAL_FILTERING.page,
-      order: selectedOrder as OrderType,
-    });
-  };
-  const handleChangePages = (page: number) => {
-    handleChangeState({ ...state, page });
-  };
   const handleChangeSearchTitle = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -130,11 +104,7 @@ const Feed = () => {
 
     searchTitleRef?.current?.blur();
 
-    handleChangeState({
-      ...state,
-      page: INITIAL_FILTERING.page,
-      searchTitle: trimmedSearchTitle,
-    });
+    handleChanges(trimmedSearchTitle, "searchTitle");
   };
 
   const handleBookmarkDelete = (id: number) => {
@@ -210,111 +180,94 @@ const Feed = () => {
       />
 
       <PageLayout>
-        <PageLayout.Aside>
-          {isRouterReady ? (
-            <FeedFilterMenu
-              getCategoryData={handleChangeCategory}
-              category={state.category}
-            />
-          ) : null}
-        </PageLayout.Aside>
-
         <PageLayout.Article>
-          <Layout>
+          <Wrapper>
             <Title>피드 페이지</Title>
+            <FeedFilterDiv>
+              <Select
+                version2
+                selectedOption={{
+                  value: state.category,
+                  text: state.category,
+                }}
+                onChange={(category) => handleChanges(category, "category")}
+              >
+                <Select.Trigger>선택</Select.Trigger>
+                <Select.OptionList>
+                  {["전체", ...CATEGORY].map((category) => (
+                    <Select.Option value={category} key={category}>
+                      {category}
+                    </Select.Option>
+                  ))}
+                </Select.OptionList>
+              </Select>
 
-            <Form action="submit" onSubmit={handleChangeSearchTitle}>
-              <SearchTitle>
+              <form action="submit" onSubmit={handleChangeSearchTitle}>
                 <Input
                   searchIcon
                   name="searchTitle"
                   ref={searchTitleRef}
+                  endIcon
+                  style={{ border: 0 }}
                   value={searchTitleInputValue}
                   onChange={(e) => setSearchTitleInputValue(e.target.value)}
                   autoFocus
                 />
-                <Button
-                  colorType="main-color"
-                  buttonType="small"
-                  type="submit"
-                  width="82"
-                >
-                  검색
-                </Button>
-              </SearchTitle>
+              </form>
+            </FeedFilterDiv>
 
-              <Select
-                onChange={handleChangeOrder}
-                selectedOption={{
-                  value: state.order,
-                  text: state.order === "upload" ? "최신 순" : "좋아요 순",
-                }}
-              >
-                <Select.Trigger>정렬</Select.Trigger>
-                <Select.OptionList>
-                  <Select.Option value="upload">최신 순</Select.Option>
-                  <Select.Option value="like">좋아요 순</Select.Option>
-                </Select.OptionList>
-              </Select>
-            </Form>
+            {state.searchTitle !== "" && feedBookmarks.totalCount === 0 ? (
+              <NoResult />
+            ) : (
+              <>
+                <SubFilterDiv>
+                  <h2>전체 {feedBookmarks?.totalCount.toLocaleString()}개</h2>
+                  <Select
+                    onChange={(order) => handleChanges(order, "order")}
+                    selectedOption={{
+                      value: state.order,
+                      text: SortType[state.order],
+                    }}
+                    version2
+                  >
+                    <Select.Trigger>선택</Select.Trigger>
+                    <Select.OptionList>
+                      <Select.Option value="upload">최신 순</Select.Option>
+                      <Select.Option value="like">좋아요 순</Select.Option>
+                    </Select.OptionList>
+                  </Select>
+                </SubFilterDiv>
 
-            <BookmarkContainer>
-              {state.searchTitle !== "" && feedBookmarks.totalCount === 0 ? (
-                <NoResult />
-              ) : (
-                feedBookmarks.bookmarks.map((bookmark) => (
-                  <BookmarkCard
-                    key={bookmark.id}
-                    data={bookmark}
-                    deleteBookmark={handleBookmarkDelete}
-                    isMine={profileId === bookmark.profile?.profileId}
-                  />
-                ))
-              )}
-            </BookmarkContainer>
+                <CardWrap>
+                  {feedBookmarks.bookmarks.map((bookmark) => (
+                    <BookmarkCard
+                      key={bookmark.id}
+                      data={bookmark}
+                      deleteBookmark={handleBookmarkDelete}
+                      isMine={profileId === bookmark.profile?.profileId}
+                    />
+                  ))}
+                </CardWrap>
+              </>
+            )}
 
-            <div style={{ display: "flex", justifyContent: "center" }}>
+            <PaginationDiv>
               <Pagination
-                defaultPage={state.page}
                 count={Math.ceil(feedBookmarks.totalCount / state.size)}
-                onChange={handleChangePages}
+                onChange={(pageNum) => handleChanges(pageNum, "page")}
+                defaultPage={state.page}
               />
-            </div>
-          </Layout>
+            </PaginationDiv>
+          </Wrapper>
         </PageLayout.Article>
       </PageLayout>
     </>
   );
 };
 
-const Layout = styled.div`
+const FeedFilterDiv = styled(FilterDiv)`
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 835px;
-  margin: 0 auto;
-`;
-
-const Title = styled.h2`
-  margin: 9px 0 35px 15px;
-  color: ${theme.color.$gray800};
-  ${theme.text.$headline5};
-`;
-
-const Form = styled.form`
-  display: inline-flex;
-  justify-content: space-between;
-  margin-bottom: 37px;
-`;
-
-const SearchTitle = styled.div`
-  display: flex;
-  gap: 10px;
-`;
-
-const BookmarkContainer = styled.div`
-  margin-bottom: 90px;
-  min-height: 288px;
+  gap: 14px;
 `;
 
 export default Feed;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -37,3 +37,5 @@ export const CATEGORY_MAP = {
   여행: { color: "#82DD4A", fileName: "travel" },
   요리: { color: "#966353", fileName: "cooking" },
 } as const;
+
+export const PAGE_SIZE = 20;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- 피드 페이지 버전2 디자인 반영

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 피드페이지 버전2 디자인 반영
- 한 페이지에 보이는 북마크 목록 개수 변경(8 -> 20)
  - 요청은 20개로 변경했으나 API 오류가 있어 아직은 8개만 응답해주고 있습니다. 해당 부분은 노션에 Q&A 작성했고 백엔드에서 확인 중입니다.
- 검색 결과가 없을 때 보이는 `NoResult` 컴포넌트 또한 버전2 디자인에 맞추기 위해 `max-width` 값 제거


https://user-images.githubusercontent.com/96400112/193459501-2c93ed39-7bf1-4dcc-bca1-737818c41c48.mp4



<!-- closes #이슈번호 -->
closes #402