### PR TITLE
Feature/#418-refreshToken 도입

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,17 +4,17 @@ import { useEffect, useCallback } from "react";
 import styled from "@emotion/styled";
 import { Meta } from "@/components/common";
 import GoogleLoginButton from "@/components/main/googleLoginButton";
-import profileAPI from "@/utils/apis/profile";
 import storage from "@/utils/localStorage";
 import { LINKOCEAN_PATH, STORAGE_KEY } from "@/utils/constants";
 import * as theme from "@/styles/theme";
+import authAPI from "@/utils/apis/auth";
 
 export default function Home() {
   const router = useRouter();
 
   const loginSuccess = useCallback(async () => {
     try {
-      const response = await profileAPI.loginSuccess();
+      const response = await authAPI.loginSuccess();
       const nextPage = response.data.hasProfile
         ? LINKOCEAN_PATH.myFavorite
         : LINKOCEAN_PATH.signup;
@@ -32,7 +32,7 @@ export default function Home() {
       }
 
       try {
-        const response = await profileAPI.auth(code);
+        const response = await authAPI.auth(code);
         storage.setItem(STORAGE_KEY.token, response.data.accessToken);
         storage.setItem(STORAGE_KEY.refreshToken, response.data.refreshToken);
         loginSuccess();

--- a/types/type.ts
+++ b/types/type.ts
@@ -62,3 +62,9 @@ export type RobotsType =
   | "index, nofollow";
 
 export type FollowTabType = "follower" | "followee";
+
+export type AuthResponse = {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+};

--- a/utils/apis/auth.ts
+++ b/utils/apis/auth.ts
@@ -1,0 +1,14 @@
+import { AuthResponse } from "@/types/type";
+import { authInstance, unauthInstance } from "./instance";
+
+const authAPI = {
+  auth: (code: string) =>
+    unauthInstance.post<AuthResponse>("/auth/google", {
+      code,
+      redirectUri: window.location.origin,
+    }),
+  loginSuccess: () =>
+    authInstance.get<{ hasProfile: boolean }>("/login/success"),
+};
+
+export default authAPI;

--- a/utils/apis/instance.ts
+++ b/utils/apis/instance.ts
@@ -1,20 +1,44 @@
 import axios from "axios";
 import storage from "@/utils/localStorage";
+import { STORAGE_KEY } from "@/utils/constants";
+import { AuthResponse } from "@/types/type";
+import useLogout from "@/hooks/useLogout";
 
 const baseURL = `${process.env.END_POINT}/api/v1`;
 
 const unauthInstance = axios.create({ baseURL });
 const authInstance = axios.create({ baseURL });
-authInstance.interceptors.request.use(
-  (config) => {
-    // eslint-disable-next-line no-param-reassign
-    config.headers = {
-      Authorization: `Bearer ${storage.getItem("LINKOCEAN_TOKEN", "")}`,
-    };
+authInstance.interceptors.request.use((config) => {
+  // eslint-disable-next-line no-param-reassign
+  config.headers = {
+    Authorization: `Bearer ${storage.getItem("LINKOCEAN_TOKEN", "")}`,
+  };
 
-    return config;
-  },
-  (error) => Promise.reject(error)
+  return config;
+});
+authInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      try {
+        const response = await unauthInstance.post<AuthResponse>(
+          "/auth/token/refresh",
+          {
+            refreshToken: storage.getItem(STORAGE_KEY.refreshToken, null),
+            tokenType: "Bearer",
+          }
+        );
+        storage.setItem(STORAGE_KEY.token, response.data.accessToken);
+        storage.setItem(STORAGE_KEY.refreshToken, response.data.refreshToken);
+
+        return await authInstance.request(error.config);
+      } catch (err) {
+        useLogout()();
+      }
+    }
+
+    return Promise.reject(error);
+  }
 );
 
 export { unauthInstance, authInstance };

--- a/utils/apis/profile.ts
+++ b/utils/apis/profile.ts
@@ -1,26 +1,13 @@
 import { ProfileDetail, ProfileList } from "@/types/model";
 import { CATEGORY } from "@/types/type";
-import { unauthInstance, authInstance } from "./instance";
+import { authInstance } from "./instance";
 
 export type ProfilesPayload = {
   username: string;
   categories: typeof CATEGORY[number][];
 };
-type AuthResponse = {
-  accessToken: string;
-  refreshToken: string;
-  tokenType: string;
-};
 
 const profileAPI = {
-  auth: (code: string) =>
-    unauthInstance.post<AuthResponse>("/auth/google", {
-      code,
-      redirectUri: window.location.origin,
-    }),
-  loginSuccess: () =>
-    authInstance.get<{ hasProfile: boolean }>("/login/success"),
-  logout: () => authInstance.post("/users/logout"),
   createProfile: (payload: ProfilesPayload) =>
     authInstance.post<{ id: number }>("/profiles", payload),
   getOtherProfile: (profileId: number) =>


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description (미정) -->

# 개요

<!-- 간략 설명 -->
- refresh token 도입

# 작업사항

<!-- 상세 설명 관련이미지 첨부 -->
- 인증이 필요한 API 401 에러 응답 -> access token 재발급하는 `refresh API` 호출
  - 정상 응답: 재발급한 access token, refresh token을 로컬 스토리지에 저장 후 요청에 실패한 API 재호출
    ![refresh](https://user-images.githubusercontent.com/96400112/194914903-096f108c-60c8-42e4-8112-e4442c6a05f6.PNG)
  - 에러 응답: 로그아웃 처리



access token 만료기간이 10시간이라 충분히 테스트를 못 했는데..어떤 버그가 있을지 모르겠습니다😭
<!-- closes #이슈번호 -->
closes #418 